### PR TITLE
Develop submission flow

### DIFF
--- a/assets/js/aco_checkout.js
+++ b/assets/js/aco_checkout.js
@@ -391,6 +391,24 @@ jQuery(function($) {
 			}
 		},
 
+		/**
+		 * Logs the message to the Avarda log in WooCommerce.
+		 * @param {string} message 
+		 */
+		logToFile: function( message ) {
+			$.ajax(
+				{
+					url: aco_wc_params.log_to_file_url,
+					type: 'POST',
+					dataType: 'json',
+					data: {
+						message: message,
+						nonce: aco_wc_params.log_to_file_nonce
+					}
+				}
+			);
+		},
+
 		/*
 		 * Initiates the script and sets the triggers for the functions.
 		 */

--- a/assets/js/aco_checkout.js
+++ b/assets/js/aco_checkout.js
@@ -261,26 +261,6 @@ jQuery(function($) {
 			});
 		},
 
-		hashChange: function() {
-			console.log('hashchange');
-			var currentHash = location.hash;
-            var splittedHash = currentHash.split("=");
-            console.log(splittedHash[0]);
-            console.log(splittedHash[1]);
-            if(splittedHash[0] === "#avarda-success"){
-				$( 'body' ).trigger( 'aco_order_validation', true );
-				var response = JSON.parse( atob( splittedHash[1] ) );
-                console.log('response.redirect_url');
-                console.log(response.redirect_url);
-				sessionStorage.setItem( 'avardaRedirectUrl', response.redirect_url );
-				$('form.checkout').removeClass( 'processing' ).unblock();
-            }
-		},
-
-		errorDetected: function() {
-			$( 'body' ).trigger( 'aco_order_validation', false );
-		},
-
 		/*
 		 * Check if our gateway is the selected gateway.
 		 */
@@ -495,10 +475,6 @@ jQuery(function($) {
 				// Update avarda payment.
 				aco_wc.bodyEl.on('updated_checkout', aco_wc.updateAvardaPayment);
  				
-				// Hashchange.
-				//$( window ).on('hashchange', aco_wc.hashChange);
-				// Error detected.
-				// $( document.body ).on( 'checkout_error', aco_wc.errorDetected );
 			}
 			aco_wc.bodyEl.on('change', 'input[name="payment_method"]', aco_wc.maybeChangeToACO);
 			aco_wc.bodyEl.on( 'click', aco_wc.selectAnotherSelector, aco_wc.changeFromACO );

--- a/avarda-checkout-for-woocommerce.php
+++ b/avarda-checkout-for-woocommerce.php
@@ -245,6 +245,7 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 						'iframe_shipping_address_change_nonce' => wp_create_nonce( 'aco_wc_iframe_shipping_address_change' ),
 						'log_to_file_url'              => WC_AJAX::get_endpoint( 'aco_wc_log_js' ),
 						'log_to_file_nonce'            => wp_create_nonce( 'aco_wc_log_js' ),
+						'submit_order'                 => WC_AJAX::get_endpoint( 'checkout' ),
 						'required_fields_text'         => __( 'Please fill in all required checkout fields.', 'avarda-checkout-for-woocommerce' ),
 						'aco_jwt_token'                => WC()->session->get( 'aco_wc_jwt' ),
 						'aco_redirect_url'             => wc_get_checkout_url(),

--- a/avarda-checkout-for-woocommerce.php
+++ b/avarda-checkout-for-woocommerce.php
@@ -243,6 +243,8 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 						'get_avarda_payment_nonce'     => wp_create_nonce( 'aco_wc_get_avarda_payment' ),
 						'iframe_shipping_address_change_url' => WC_AJAX::get_endpoint( 'aco_wc_iframe_shipping_address_change' ),
 						'iframe_shipping_address_change_nonce' => wp_create_nonce( 'aco_wc_iframe_shipping_address_change' ),
+						'log_to_file_url'              => WC_AJAX::get_endpoint( 'aco_wc_log_js' ),
+						'log_to_file_nonce'            => wp_create_nonce( 'aco_wc_log_js' ),
 						'required_fields_text'         => __( 'Please fill in all required checkout fields.', 'avarda-checkout-for-woocommerce' ),
 						'aco_jwt_token'                => WC()->session->get( 'aco_wc_jwt' ),
 						'aco_redirect_url'             => wc_get_checkout_url(),

--- a/avarda-checkout-for-woocommerce.php
+++ b/avarda-checkout-for-woocommerce.php
@@ -210,7 +210,7 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 		 * Loads the needed scripts for Avarda_Checkout.
 		 */
 		public function load_scripts() {
-			if ( is_checkout() ) {
+			if ( is_checkout() && ! is_wc_endpoint_url( 'order-received' ) ) {
 					do_action( 'aco_before_load_scripts' );
 
 					// Checkout script.

--- a/classes/class-aco-ajax.php
+++ b/classes/class-aco-ajax.php
@@ -29,6 +29,7 @@ class ACO_AJAX extends WC_AJAX {
 			'aco_wc_get_avarda_payment'             => true,
 			'aco_wc_iframe_shipping_address_change' => true,
 			'aco_wc_change_payment_method'          => true,
+			'aco_wc_log_js'                         => true,
 		);
 		foreach ( $ajax_events as $ajax_event => $nopriv ) {
 			add_action( 'wp_ajax_woocommerce_' . $ajax_event, array( __CLASS__, $ajax_event ) );
@@ -230,6 +231,25 @@ class ACO_AJAX extends WC_AJAX {
 		);
 		wp_die();
 
+	}
+
+	/**
+	 * Logs messages from the JavaScript to the server log.
+	 *
+	 * @return void
+	 */
+	public static function aco_wc_log_js() {
+		$nonce = isset( $_POST['nonce'] ) ? sanitize_key( $_POST['nonce'] ) : '';
+		if ( ! wp_verify_nonce( $nonce, 'aco_wc_log_js' ) ) {
+			wp_send_json_error( 'bad_nonce' );
+			exit;
+		}
+		$posted_message     = isset( $_POST['message'] ) ? sanitize_text_field( wp_unslash( $_POST['message'] ) ) : '';
+		$avarda_purchase_id = WC()->session->get( 'aco_wc_purchase_id' );
+		$message            = "Frontend JS $avarda_purchase_id: $posted_message";
+		ACO_Logger::log( $message );
+		wp_send_json_success();
+		wp_die();
 	}
 }
 ACO_AJAX::init();

--- a/classes/class-aco-gateway.php
+++ b/classes/class-aco-gateway.php
@@ -82,13 +82,9 @@ class ACO_Gateway extends WC_Payment_Gateway {
 				),
 				wc_get_checkout_url()
 			);
-			$response         = array(
-				'redirect_url' => $confirmation_url,
-				'time'         => microtime(),
-			);
 			return array(
-				'result'   => 'success',
-				'redirect' => '#avarda-success=' . base64_encode( wp_json_encode( $response ) ),
+				'result'       => 'success',
+				'redirect_url' => $confirmation_url,
 			);
 		} else {
 			return array(


### PR DESCRIPTION
Instead of relying on a hash change when WooCommerce _process_payment_ function has run, we now submit the checkout form the Avarda plugin and handle the respons from process_payment ourselves. 