### PR TITLE
Add assets class + only create Avarda payment session if Avarda checkout about to be displayed in checkout page

### DIFF
--- a/assets/js/aco_checkout.js
+++ b/assets/js/aco_checkout.js
@@ -374,37 +374,6 @@ jQuery(function($) {
 			});
 		},
 
-		// When payment method is changed to ACO in regular WC Checkout page.
-		maybeChangeToACO: function() {
-			if ( 'aco' === $(this).val() ) {
-
-				$(aco_wc.checkoutFormSelector).block({
-					message: null,
-					overlayCSS: {
-						background: '#fff',
-						opacity: 0.6
-					}
-				});
-
-				$('.woocommerce-info').remove();
-
-				$.ajax({
-					type: 'POST',
-					data: {
-						aco: true,
-						nonce: aco_wc_params.change_payment_method_nonce
-					},
-					dataType: 'json',
-					url: aco_wc_params.change_payment_method_url,
-					success: function (data) {},
-					error: function (data) {},
-					complete: function (data) {
-						window.location.href = data.responseJSON.data.redirect;
-					}
-				});
-			}
-		},
-
 		/**
 		 * Maybe freezes the iframe to prevent anyone from completing the order before filling in all required fields.
 		 * 
@@ -548,7 +517,6 @@ jQuery(function($) {
 				aco_wc.bodyEl.on('updated_checkout', aco_wc.updateAvardaPayment);
  				
 			}
-			aco_wc.bodyEl.on('change', 'input[name="payment_method"]', aco_wc.maybeChangeToACO);
 			aco_wc.bodyEl.on( 'click', aco_wc.selectAnotherSelector, aco_wc.changeFromACO );
 		},
 	}

--- a/assets/js/aco_utility.js
+++ b/assets/js/aco_utility.js
@@ -1,0 +1,47 @@
+jQuery(function($) {
+	const aco_utility = {
+        bodyEl: $('body'),
+        checkoutFormSelector: 'form.checkout',
+
+		// When payment method is changed to ACO in regular WC Checkout page.
+		maybeChangeToACO: function() {
+			if ( 'aco' === $(this).val() ) {
+
+				$(aco_utility.checkoutFormSelector).block({
+					message: null,
+					overlayCSS: {
+						background: '#fff',
+						opacity: 0.6
+					}
+				});
+
+				$('.woocommerce-info').remove();
+
+				$.ajax({
+					type: 'POST',
+					data: {
+						aco: true,
+						nonce: aco_utility_params.change_payment_method_nonce
+					},
+					dataType: 'json',
+					url: aco_utility_params.change_payment_method_url,
+					success: function (data) {},
+					error: function (data) {},
+					complete: function (data) {
+						window.location.href = data.responseJSON.data.redirect;
+					}
+				});
+			}
+		},
+
+
+
+		/*
+		 * Initiates the script and sets the triggers for the functions.
+		 */
+		init: function() {
+			aco_utility.bodyEl.on('change', 'input[name="payment_method"]', aco_utility.maybeChangeToACO);
+		},
+	}
+	aco_utility.init();
+});

--- a/avarda-checkout-for-woocommerce.php
+++ b/avarda-checkout-for-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name:     Avarda Checkout for WooCommerce
  * Plugin URI:      http://krokedil.com/
  * Description:     Provides an Avarda Checkout gateway for WooCommerce.
- * Version:         1.6.1
+ * Version:         1.6.2
  * Author:          Krokedil
  * Author URI:      http://krokedil.com/
  * Developer:       Krokedil
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'AVARDA_CHECKOUT_VERSION', '1.6.1' );
+define( 'AVARDA_CHECKOUT_VERSION', '1.6.2' );
 define( 'AVARDA_CHECKOUT_URL', untrailingslashit( plugins_url( '/', __FILE__ ) ) );
 define( 'AVARDA_CHECKOUT_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'AVARDA_CHECKOUT_LIVE_ENV', 'https://avdonl-p-checkout.avarda.org' );

--- a/avarda-checkout-for-woocommerce.php
+++ b/avarda-checkout-for-woocommerce.php
@@ -145,12 +145,8 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 
 			$this->include_files();
 
-			// Load scripts.
-			add_action( 'wp_enqueue_scripts', array( $this, 'load_scripts' ) );
 			// Delete transient when aco settings is saved.
 			add_action( 'woocommerce_update_options_checkout_aco', array( $this, 'aco_delete_transients' ) );
-
-			add_action( 'aco_before_load_scripts', array( $this, 'aco_maybe_initialize_payment' ) );
 
 			// Set class variables.
 			$this->api              = new ACO_API();
@@ -177,36 +173,6 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 		}
 
 		/**
-		 * Maybe initialize payment.
-		 *
-		 * @param int $order_id The WooCommerce Order id.
-		 *
-		 * @return void
-		 */
-		public function aco_maybe_initialize_payment( $order_id = null ) {
-
-			if ( ! empty( $order_id ) ) {
-				// Creates a session and store it to order if we don't have a previous one or if it has expired.
-				$avarda_jwt_expired_time = get_post_meta( $order_id, '_wc_avarda_expiredUtc', true );
-				if ( empty( $avarda_jwt_expired_time ) || strtotime( $avarda_jwt_expired_time ) < time() ) {
-					delete_post_meta( $order_id, '_wc_avarda_purchase_id' );
-					delete_post_meta( $order_id, '_wc_avarda_jwt' );
-					delete_post_meta( $order_id, '_wc_avarda_expiredUtc' );
-					aco_wc_initialize_or_update_order_from_wc_order( $order_id );
-				}
-			} else {
-				// Creates jwt token if we do not have session var set with jwt token or if it have expired.
-				$avarda_payment_data     = WC()->session->get( 'aco_wc_payment_data' );
-				$avarda_jwt_expired_time = ( is_array( $avarda_payment_data ) && isset( $avarda_payment_data['expiredUtc'] ) ) ? $avarda_payment_data['expiredUtc'] : '';
-				$token                   = ( time() < strtotime( $avarda_jwt_expired_time ) ) ? 'session' : 'new_token_required';
-				if ( 'new_token_required' === $token || null === $avarda_payment_data['jwt'] || get_woocommerce_currency() !== WC()->session->get( 'aco_currency' ) || ACO_WC()->checkout_setup->get_language() !== WC()->session->get( 'aco_language' ) ) {
-					aco_wc_initialize_payment();
-				}
-			}
-
-		}
-
-		/**
 		 * Includes the files for the plugin
 		 *
 		 * @return void
@@ -218,6 +184,7 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 				include_once AVARDA_CHECKOUT_PATH . '/classes/class-aco-templates.php';
 			}
 
+			include_once AVARDA_CHECKOUT_PATH . '/classes/class-aco-assets.php';
 			include_once AVARDA_CHECKOUT_PATH . '/classes/class-aco-ajax.php';
 			include_once AVARDA_CHECKOUT_PATH . '/classes/class-aco-api.php';
 			include_once AVARDA_CHECKOUT_PATH . '/classes/class-aco-gateway.php';
@@ -280,127 +247,6 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 		public function get_setting_link() {
 			$section_slug = 'aco';
 			return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $section_slug );
-		}
-
-		/**
-		 * Loads the needed scripts for Avarda_Checkout.
-		 */
-		public function load_scripts() {
-			if ( isset( $_GET['pay_for_order'] ) && 'true' === $_GET['pay_for_order'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				return;
-			}
-
-			if ( 'redirect' === $this->checkout_flow && is_checkout() && ! is_wc_endpoint_url( 'order-pay' ) ) {
-				return;
-			}
-
-			if ( is_checkout() && ! is_wc_endpoint_url( 'order-received' ) ) {
-
-				$key      = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
-				$order_id = ! empty( $key ) ? wc_get_order_id_by_order_key( $key ) : 0;
-
-				do_action( 'aco_before_load_scripts', $order_id );
-
-				$is_aco_action    = 'no';
-				$confirmation_url = '';
-
-				// Confirmation url for order pay.
-				if ( is_wc_endpoint_url( 'order-pay' ) ) {
-					$is_aco_action    = 'yes';
-					$order            = wc_get_order( $order_id );
-					$confirmation_url = add_query_arg(
-						array(
-							'aco_confirm'     => 'yes',
-							'aco_purchase_id' => get_post_meta( $order_id, '_wc_avarda_purchase_id', true ),
-						),
-						$order->get_checkout_order_received_url()
-					);
-				}
-
-				// Confirmation url for subscription payment change.
-				if ( isset( $_GET['aco-action'], $_GET['key'] ) && 'change-subs-payment' === $_GET['aco-action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					$is_aco_action    = 'yes';
-					$order            = wc_get_order( $order_id );
-					$confirmation_url = add_query_arg(
-						array(
-							'aco-action'   => 'subs-payment-changed',
-							'aco-order-id' => $order_id,
-						),
-						$order->get_view_order_url()
-					);
-				}
-
-				if ( empty( $order_id ) ) {
-					// If we don't have an order - get JWT from session.
-					$avarda_payment_data = WC()->session->get( 'aco_wc_payment_data' );
-					$avarda_jwt_token    = ( is_array( $avarda_payment_data ) && isset( $avarda_payment_data['jwt'] ) ) ? $avarda_payment_data['jwt'] : '';
-					$redirect_url        = wc_get_checkout_url();
-				} else {
-					// We have a WC order - get info from that.
-					$avarda_jwt_token = get_post_meta( $order_id, '_wc_avarda_jwt', true );
-					// Get current url (pay page).
-					$redirect_url = $order->get_checkout_payment_url( true );
-				}
-
-				// Checkout script.
-				wp_register_script(
-					'aco_wc',
-					AVARDA_CHECKOUT_URL . '/assets/js/aco_checkout.js',
-					array( 'jquery' ),
-					AVARDA_CHECKOUT_VERSION,
-					true
-				);
-				$standard_woo_checkout_fields = apply_filters( 'aco_ignored_checkout_fields', array( 'billing_first_name', 'billing_last_name', 'billing_address_1', 'billing_address_2', 'billing_postcode', 'billing_city', 'billing_phone', 'billing_email', 'billing_state', 'billing_country', 'billing_company', 'shipping_first_name', 'shipping_last_name', 'shipping_address_1', 'shipping_address_2', 'shipping_postcode', 'shipping_city', 'shipping_state', 'shipping_country', 'shipping_company', 'terms', 'terms-field', '_wp_http_referer', 'ship_to_different_address', 'calc_shipping_country', 'calc_shipping_state', 'calc_shipping_postcode' ) );
-				$avarda_settings              = get_option( 'woocommerce_aco_settings' );
-				$aco_test_mode                = ( isset( $avarda_settings['testmode'] ) && 'yes' === $avarda_settings['testmode'] ) ? true : false;
-				$aco_two_column_checkout      = ( isset( $avarda_settings['two_column_checkout'] ) && 'yes' === $avarda_settings['two_column_checkout'] ) ? array( 'two_column' => true ) : array( 'two_column' => false );
-				$styles                       = new stdClass(); // empty object as default value.
-				$aco_custom_css_styles        = apply_filters( 'aco_custom_css_styles', $styles );
-
-				$params = array(
-					'ajax_url'                             => admin_url( 'admin-ajax.php' ),
-					'select_another_method_text'           => __( 'Select another payment method', 'avarda-checkout-for-woocommerce' ),
-					'standard_woo_checkout_fields'         => $standard_woo_checkout_fields,
-					'address_changed_url'                  => WC_AJAX::get_endpoint( 'aco_wc_address_changed' ),
-					'address_changed_nonce'                => wp_create_nonce( 'aco_wc_address_changed' ),
-					'update_payment_url'                   => WC_AJAX::get_endpoint( 'aco_wc_update_checkout' ),
-					'update_payment_nonce'                 => wp_create_nonce( 'aco_wc_update_checkout' ),
-					'change_payment_method_url'            => WC_AJAX::get_endpoint( 'aco_wc_change_payment_method' ),
-					'change_payment_method_nonce'          => wp_create_nonce( 'aco_wc_change_payment_method' ),
-					'get_avarda_payment_url'               => WC_AJAX::get_endpoint( 'aco_wc_get_avarda_payment' ),
-					'get_avarda_payment_nonce'             => wp_create_nonce( 'aco_wc_get_avarda_payment' ),
-					'iframe_shipping_address_change_url'   => WC_AJAX::get_endpoint( 'aco_wc_iframe_shipping_address_change' ),
-					'iframe_shipping_address_change_nonce' => wp_create_nonce( 'aco_wc_iframe_shipping_address_change' ),
-					'log_to_file_url'                      => WC_AJAX::get_endpoint( 'aco_wc_log_js' ),
-					'log_to_file_nonce'                    => wp_create_nonce( 'aco_wc_log_js' ),
-					'submit_order'                         => WC_AJAX::get_endpoint( 'checkout' ),
-					'required_fields_text'                 => __( 'Please fill in all required checkout fields.', 'avarda-checkout-for-woocommerce' ),
-					'aco_jwt_token'                        => $avarda_jwt_token,
-					'aco_redirect_url'                     => $redirect_url,
-					'aco_test_mode'                        => $aco_test_mode,
-					'aco_checkout_layout'                  => $aco_two_column_checkout,
-					'aco_checkout_style'                   => $aco_custom_css_styles,
-					'is_aco_action'                        => $is_aco_action,
-					'aco_order_id'                         => $order_id,
-					'confirmation_url'                     => $confirmation_url,
-
-				);
-
-				wp_localize_script(
-					'aco_wc',
-					'aco_wc_params',
-					$params
-				);
-				wp_enqueue_script( 'aco_wc' );
-
-				wp_register_style(
-					'aco',
-					AVARDA_CHECKOUT_URL . '/assets/css/aco_style.css',
-					array(),
-					AVARDA_CHECKOUT_VERSION
-				);
-				wp_enqueue_style( 'aco' );
-			}
 		}
 
 		/**

--- a/classes/class-aco-assets.php
+++ b/classes/class-aco-assets.php
@@ -30,7 +30,9 @@ class ACO_Assets {
 
 		// Load scripts.
 		add_action( 'wp_enqueue_scripts', array( $this, 'load_scripts' ) );
-		add_action( 'aco_localize_and_enqueue_checkout_script', array( $this, 'localize_and_enqueue_checkout_script' ) );
+
+		add_action( 'aco_wc_before_checkout_form', array( $this, 'localize_and_enqueue_checkout_script' ) );
+		add_action( 'aco_wc_before_order_receipt', array( $this, 'localize_and_enqueue_checkout_script' ) );
 
 	}
 
@@ -48,6 +50,27 @@ class ACO_Assets {
 
 		if ( is_checkout() && ! is_wc_endpoint_url( 'order-received' ) ) {
 
+			// Checkout utility (change to Avarda payment method in checkout).
+			wp_register_script(
+				'aco_utility',
+				AVARDA_CHECKOUT_URL . '/assets/js/aco_utility.js',
+				array( 'jquery' ),
+				AVARDA_CHECKOUT_VERSION,
+				true
+			);
+
+			$params = array(
+				'change_payment_method_url'   => WC_AJAX::get_endpoint( 'aco_wc_change_payment_method' ),
+				'change_payment_method_nonce' => wp_create_nonce( 'aco_wc_change_payment_method' ),
+			);
+
+			wp_localize_script(
+				'aco_utility',
+				'aco_utility_params',
+				$params
+			);
+			wp_enqueue_script( 'aco_utility' );
+
 			// Checkout script.
 			wp_register_script(
 				'aco_wc',
@@ -57,6 +80,7 @@ class ACO_Assets {
 				true
 			);
 
+			// Checkout style.
 			wp_register_style(
 				'aco',
 				AVARDA_CHECKOUT_URL . '/assets/css/aco_style.css',

--- a/classes/class-aco-assets.php
+++ b/classes/class-aco-assets.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Main assets file.
+ *
+ * @package Avarda_Checkout/Classes/
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * ACO_Assets class.
+ */
+class ACO_Assets {
+
+	/**
+	 * The plugin settings.
+	 *
+	 * @var array
+	 */
+	public $settings;
+
+	/**
+	 * ACO_Assets constructor.
+	 */
+	public function __construct() {
+		$avarda_settings     = get_option( 'woocommerce_aco_settings' );
+		$this->checkout_flow = isset( $avarda_settings['checkout_flow'] ) ? $avarda_settings['checkout_flow'] : 'embedded';
+
+		// Load scripts.
+		add_action( 'wp_enqueue_scripts', array( $this, 'load_scripts' ) );
+		add_action( 'aco_localize_and_enqueue_checkout_script', array( $this, 'localize_and_enqueue_checkout_script' ) );
+
+	}
+
+	/**
+	 * Loads the needed scripts for Avarda_Checkout.
+	 */
+	public function load_scripts() {
+		if ( isset( $_GET['pay_for_order'] ) && 'true' === $_GET['pay_for_order'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		if ( 'redirect' === $this->checkout_flow && is_checkout() && ! is_wc_endpoint_url( 'order-pay' ) ) {
+			return;
+		}
+
+		if ( is_checkout() && ! is_wc_endpoint_url( 'order-received' ) ) {
+
+			// Checkout script.
+			wp_register_script(
+				'aco_wc',
+				AVARDA_CHECKOUT_URL . '/assets/js/aco_checkout.js',
+				array( 'jquery' ),
+				AVARDA_CHECKOUT_VERSION,
+				true
+			);
+
+			wp_register_style(
+				'aco',
+				AVARDA_CHECKOUT_URL . '/assets/css/aco_style.css',
+				array(),
+				AVARDA_CHECKOUT_VERSION
+			);
+			wp_enqueue_style( 'aco' );
+		}
+	}
+
+
+	/**
+	 * Loads the needed scripts for Avarda_Checkout.
+	 */
+	public function localize_and_enqueue_checkout_script() {
+
+		$key      = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
+		$order_id = ! empty( $key ) ? wc_get_order_id_by_order_key( $key ) : 0;
+
+		$this->aco_maybe_initialize_payment( $order_id );
+
+		$is_aco_action    = 'no';
+		$confirmation_url = '';
+
+		// Confirmation url for order pay.
+		if ( is_wc_endpoint_url( 'order-pay' ) ) {
+			$is_aco_action    = 'yes';
+			$order            = wc_get_order( $order_id );
+			$confirmation_url = add_query_arg(
+				array(
+					'aco_confirm'     => 'yes',
+					'aco_purchase_id' => get_post_meta( $order_id, '_wc_avarda_purchase_id', true ),
+				),
+				$order->get_checkout_order_received_url()
+			);
+		}
+
+		// Confirmation url for subscription payment change.
+		if ( isset( $_GET['aco-action'], $_GET['key'] ) && 'change-subs-payment' === $_GET['aco-action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$is_aco_action    = 'yes';
+			$order            = wc_get_order( $order_id );
+			$confirmation_url = add_query_arg(
+				array(
+					'aco-action'   => 'subs-payment-changed',
+					'aco-order-id' => $order_id,
+				),
+				$order->get_view_order_url()
+			);
+		}
+
+		if ( empty( $order_id ) ) {
+			// If we don't have an order - get JWT from session.
+			$avarda_payment_data = WC()->session->get( 'aco_wc_payment_data' );
+			$avarda_jwt_token    = ( is_array( $avarda_payment_data ) && isset( $avarda_payment_data['jwt'] ) ) ? $avarda_payment_data['jwt'] : '';
+			$redirect_url        = wc_get_checkout_url();
+		} else {
+			// We have a WC order - get info from that.
+			$avarda_jwt_token = get_post_meta( $order_id, '_wc_avarda_jwt', true );
+			// Get current url (pay page).
+			$redirect_url = $order->get_checkout_payment_url( true );
+		}
+
+		$standard_woo_checkout_fields = apply_filters( 'aco_ignored_checkout_fields', array( 'billing_first_name', 'billing_last_name', 'billing_address_1', 'billing_address_2', 'billing_postcode', 'billing_city', 'billing_phone', 'billing_email', 'billing_state', 'billing_country', 'billing_company', 'shipping_first_name', 'shipping_last_name', 'shipping_address_1', 'shipping_address_2', 'shipping_postcode', 'shipping_city', 'shipping_state', 'shipping_country', 'shipping_company', 'terms', 'terms-field', '_wp_http_referer', 'ship_to_different_address', 'calc_shipping_country', 'calc_shipping_state', 'calc_shipping_postcode' ) );
+		$avarda_settings              = get_option( 'woocommerce_aco_settings' );
+		$aco_test_mode                = ( isset( $avarda_settings['testmode'] ) && 'yes' === $avarda_settings['testmode'] ) ? true : false;
+		$aco_two_column_checkout      = ( isset( $avarda_settings['two_column_checkout'] ) && 'yes' === $avarda_settings['two_column_checkout'] ) ? array( 'two_column' => true ) : array( 'two_column' => false );
+		$styles                       = new stdClass(); // empty object as default value.
+		$aco_custom_css_styles        = apply_filters( 'aco_custom_css_styles', $styles );
+
+		$params = array(
+			'ajax_url'                             => admin_url( 'admin-ajax.php' ),
+			'select_another_method_text'           => __( 'Select another payment method', 'avarda-checkout-for-woocommerce' ),
+			'standard_woo_checkout_fields'         => $standard_woo_checkout_fields,
+			'address_changed_url'                  => WC_AJAX::get_endpoint( 'aco_wc_address_changed' ),
+			'address_changed_nonce'                => wp_create_nonce( 'aco_wc_address_changed' ),
+			'update_payment_url'                   => WC_AJAX::get_endpoint( 'aco_wc_update_checkout' ),
+			'update_payment_nonce'                 => wp_create_nonce( 'aco_wc_update_checkout' ),
+			'change_payment_method_url'            => WC_AJAX::get_endpoint( 'aco_wc_change_payment_method' ),
+			'change_payment_method_nonce'          => wp_create_nonce( 'aco_wc_change_payment_method' ),
+			'get_avarda_payment_url'               => WC_AJAX::get_endpoint( 'aco_wc_get_avarda_payment' ),
+			'get_avarda_payment_nonce'             => wp_create_nonce( 'aco_wc_get_avarda_payment' ),
+			'iframe_shipping_address_change_url'   => WC_AJAX::get_endpoint( 'aco_wc_iframe_shipping_address_change' ),
+			'iframe_shipping_address_change_nonce' => wp_create_nonce( 'aco_wc_iframe_shipping_address_change' ),
+			'log_to_file_url'                      => WC_AJAX::get_endpoint( 'aco_wc_log_js' ),
+			'log_to_file_nonce'                    => wp_create_nonce( 'aco_wc_log_js' ),
+			'submit_order'                         => WC_AJAX::get_endpoint( 'checkout' ),
+			'required_fields_text'                 => __( 'Please fill in all required checkout fields.', 'avarda-checkout-for-woocommerce' ),
+			'aco_jwt_token'                        => $avarda_jwt_token,
+			'aco_redirect_url'                     => $redirect_url,
+			'aco_test_mode'                        => $aco_test_mode,
+			'aco_checkout_layout'                  => $aco_two_column_checkout,
+			'aco_checkout_style'                   => $aco_custom_css_styles,
+			'is_aco_action'                        => $is_aco_action,
+			'aco_order_id'                         => $order_id,
+			'confirmation_url'                     => $confirmation_url,
+
+		);
+
+		wp_localize_script(
+			'aco_wc',
+			'aco_wc_params',
+			$params
+		);
+		wp_enqueue_script( 'aco_wc' );
+	}
+
+	/**
+	 * Maybe initialize payment.
+	 *
+	 * @param int $order_id The WooCommerce Order id.
+	 *
+	 * @return void
+	 */
+	public function aco_maybe_initialize_payment( $order_id = null ) {
+
+		if ( ! empty( $order_id ) ) {
+			// Creates a session and store it to order if we don't have a previous one or if it has expired.
+			$avarda_jwt_expired_time = get_post_meta( $order_id, '_wc_avarda_expiredUtc', true );
+			if ( empty( $avarda_jwt_expired_time ) || strtotime( $avarda_jwt_expired_time ) < time() ) {
+				delete_post_meta( $order_id, '_wc_avarda_purchase_id' );
+				delete_post_meta( $order_id, '_wc_avarda_jwt' );
+				delete_post_meta( $order_id, '_wc_avarda_expiredUtc' );
+				aco_wc_initialize_or_update_order_from_wc_order( $order_id );
+			}
+		} else {
+			// Creates jwt token if we do not have session var set with jwt token or if it have expired.
+			$avarda_payment_data     = WC()->session->get( 'aco_wc_payment_data' );
+			$avarda_jwt_expired_time = ( is_array( $avarda_payment_data ) && isset( $avarda_payment_data['expiredUtc'] ) ) ? $avarda_payment_data['expiredUtc'] : '';
+			$token                   = ( time() < strtotime( $avarda_jwt_expired_time ) ) ? 'session' : 'new_token_required';
+			if ( 'new_token_required' === $token || null === $avarda_payment_data['jwt'] || get_woocommerce_currency() !== WC()->session->get( 'aco_currency' ) || ACO_WC()->checkout_setup->get_language() !== WC()->session->get( 'aco_language' ) ) {
+				aco_wc_initialize_payment();
+			}
+		}
+
+	}
+}
+new ACO_Assets();

--- a/classes/class-aco-checkout.php
+++ b/classes/class-aco-checkout.php
@@ -15,10 +15,11 @@ class ACO_Checkout {
 	 * Class constructor
 	 */
 	public function __construct() {
-		$settings = get_option( 'woocommerce_aco_settings' );
+		$settings            = get_option( 'woocommerce_aco_settings' );
+		$this->checkout_flow = $settings['checkout_flow'] ?? 'embedded';
 		add_action( 'woocommerce_after_calculate_totals', array( $this, 'update_avarda_order' ), 9999 );
 
-		if ( 'embedded' === $settings['checkout_flow'] ) {
+		if ( 'embedded' === $this->checkout_flow ) {
 			add_filter( 'woocommerce_checkout_fields', array( $this, 'add_hidden_jwt_token_field' ), 30 );
 		}
 	}
@@ -29,14 +30,12 @@ class ACO_Checkout {
 	 * @return void
 	 */
 	public function update_avarda_order() {
-		$settings      = get_option( 'woocommerce_aco_settings' );
-		$checkout_flow = $settings['checkout_flow'] ?? 'embedded';
 
 		if ( ! is_checkout() ) {
 			return;
 		}
 
-		if ( 'redirect' === $checkout_flow ) {
+		if ( 'redirect' === $this->checkout_flow ) {
 			return;
 		}
 

--- a/classes/class-aco-checkout.php
+++ b/classes/class-aco-checkout.php
@@ -19,7 +19,7 @@ class ACO_Checkout {
 		add_action( 'woocommerce_after_calculate_totals', array( $this, 'update_avarda_order' ), 9999 );
 
 		if ( 'embedded' === $settings['checkout_flow'] ) {
-			add_action( 'woocommerce_checkout_fields', array( $this, 'add_hidden_jwt_token_field' ), 30 );
+			add_filter( 'woocommerce_checkout_fields', array( $this, 'add_hidden_jwt_token_field' ), 30 );
 		}
 	}
 

--- a/classes/requests/checkout/post/class-aco-request-initialize-payment.php
+++ b/classes/requests/checkout/post/class-aco-request-initialize-payment.php
@@ -51,6 +51,7 @@ class ACO_Request_Initialize_Payment extends ACO_Request {
 		if ( $order_id ) {
 			$order                 = wc_get_order( $order_id );
 			$request_body['items'] = ACO_WC()->order_items->get_order_items( $order_id );
+			$request_body['extraIdentifiers']['orderReference'] = (string) $order->get_order_number();
 			// Add customer address if it exist.
 			if ( $order->get_billing_company() ) {
 				$customer_address = ACO_WC()->customer->get_b2b_customer( $order_id );

--- a/includes/aco-functions.php
+++ b/includes/aco-functions.php
@@ -421,55 +421,63 @@ function aco_set_payment_method_title( $order, $avarda_order ) {
 
 	switch ( $aco_payment_method ) {
 		case 'Invoice':
-			$method_title = __( 'Avarda Invoice', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'Invoice', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'Loan':
-			$method_title = __( 'Avarda Loan', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'Loan', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'Card':
-			$method_title = __( 'Avarda Card', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'Card', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'DirectPayment':
-			$method_title = __( 'Avarda Direct Payment', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'Direct Payment', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'PartPayment':
-			$method_title = __( 'Avarda Part Payment', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'Part Payment', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'Swish':
-			$method_title = __( 'Avarda Swish', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'Swish', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'HighAmountLoan':
 			$method_title = __( 'Avarda High Amount Loan', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'PayPal':
-			$method_title = __( 'Avarda PayPal', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'PayPal', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'PayOnDelivery':
-			$method_title = __( 'Avarda Pay On Delivery', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'Pay On Delivery', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'B2BInvoice':
-			$method_title = __( 'Avarda B2B Invoice', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'B2B Invoice', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'DirectInvoice':
-			$method_title = __( 'Avarda Direct Invoice', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'Direct Invoice', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'Masterpass':
-			$method_title = __( 'Avarda Masterpass', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'Masterpass', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'MobilePay':
-			$method_title = __( 'Avarda MobilePay', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'MobilePay', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'Vipps':
-			$method_title = __( 'Avarda Vipps', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'Vipps', 'avarda-checkout-for-woocommerce' );
 			break;
 		case 'ZeroAmount':
-			$method_title = __( 'Avarda Zero Amount', 'avarda-checkout-for-woocommerce' );
+			$method_title = __( 'Zero Amount', 'avarda-checkout-for-woocommerce' );
 			break;
 		default:
 			$method_title = __( 'Avarda Checkout', 'avarda-checkout-for-woocommerce' );
 	}
 
-	$order->set_payment_method_title( $method_title );
+	// pattern substitution.
+	$replacements               = array(
+		'{PAYMENT_METHOD_TITLE}' => $method_title,
+	);
+	$method_title_from_settings = 'Avarda {PAYMENT_METHOD_TITLE}';
+	$method_title_filtered      = str_replace( array_keys( $replacements ), $replacements, $method_title_from_settings );
+	$method_title_filtered      = apply_filters( 'aco_order_set_payment_method_title', $method_title_filtered, $method_title, $order->get_id() );
+
+	$order->set_payment_method_title( $method_title_filtered );
 	$order->save();
 }
 

--- a/includes/aco-functions.php
+++ b/includes/aco-functions.php
@@ -76,6 +76,7 @@ function aco_wc_show_checkout_form( $order_id = null ) {
 	} else {
 		aco_wc_initialize_or_update_order();
 	}
+	do_action( 'aco_localize_and_enqueue_checkout_script' );
 	?>
 	<div id="checkout-form">
 	</div>

--- a/includes/aco-functions.php
+++ b/includes/aco-functions.php
@@ -76,7 +76,6 @@ function aco_wc_show_checkout_form( $order_id = null ) {
 	} else {
 		aco_wc_initialize_or_update_order();
 	}
-	do_action( 'aco_localize_and_enqueue_checkout_script' );
 	?>
 	<div id="checkout-form">
 	</div>

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,13 @@ More information on how to get started can be found in the [plugin documentation
 
 
 == CHANGELOG ==
+= 2022.09.xx        - version 1.6.x =
+* Feature           - Adds functionality to enable custom payment method names. Can be filtered via aco_order_set_payment_method_title.
+* Tweak             - Move enqueue of JS and CSS to assets class + only run wp_localize_script & wp_enqueue_script if ACO is used. Results in Avarda purchase session only created if Avarda Checkout is about to be displayed.
+* Tweak             - Move maybeChangeToACO JS function into separate utility JS file.
+* Tweak             - Send Woo order number in init request to Avarda if available.
+
+
 = 2022.09.06        - version 1.6.1 =
 * Fix               - Confirm that the JWT token used in frontend is the same as the one stored in backend when sending session updates to Avarda.
 


### PR DESCRIPTION
* Moves enqueue of JS and CSS to assets class.
* Only run `wp_localize_script` & `wp_enqueue_script` if ACO is used. Results in Avarda purchase session only created if Avarda Checkout is about to be displayed.
* Separate maybeChangeToACO JS function into separate JS file.
* Add functionality to enable custom payment method names. Can be filtered via `aco_order_set_payment_method_title`.
* Set `orderReference` on init call when Woo order is available (mainly for redirect checkout flow).
* Fix bug related to new JWT token hidden input field that could happen if checkout flow settings wasn't saved in plugin settings page.