### PR TITLE
CU-3n5gq3q|Bug-wrong-amount-and-tax-code-for-fees

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,9 @@ More information on how to get started can be found in the [plugin documentation
 
 
 == CHANGELOG ==
+= 2022.10.xx        - version 1.x.x =
+* Fix               - Solve issue with fee amount and fee tax amount in activate order request. 
+
 = 2022.10.03        - version 1.7.0 =
 * Feature		    - Adds last 15 requests to Avarda that had an API error and display them on the WooCommerce status page. These will also be in the status report that you can send to Krokedil for support tickets.
 * Fix               - Do not try to make update payment session request to Avarda if session is in redirected to payment method state.


### PR DESCRIPTION
* Use get_item_tax_amount instead of get_product_tax_amount for products.
* Change name of get_product_price to get_item_price_incl_vat. Now used for both products and fees.