### PR TITLE
Cu 3q4g93m|bug improve when update request can be sent to avarda

### DIFF
--- a/classes/class-aco-ajax.php
+++ b/classes/class-aco-ajax.php
@@ -118,14 +118,9 @@ class ACO_AJAX extends WC_AJAX {
 			WC()->customer->set_props( $customer_data );
 			WC()->customer->save();
 
+			// Calculating totals will trigger the update Avarda session sequence in ACO_Checkout class.
 			WC()->cart->calculate_shipping();
 			WC()->cart->calculate_totals();
-
-			$avarda_order = ACO_WC()->api->request_update_payment( $avarda_purchase_id );
-
-			if ( is_wp_error( $avarda_order ) ) {
-				wp_send_json_error();
-			}
 		}
 
 		wp_send_json_success(

--- a/classes/class-aco-gateway.php
+++ b/classes/class-aco-gateway.php
@@ -201,13 +201,13 @@ class ACO_Gateway extends WC_Payment_Gateway {
 
 			// Get current status of Avarda session.
 			if ( 'B2C' === $avarda_order['mode'] ) {
-				$aco_state = $avarda_order['b2C']['step']['current'];
+				$aco_step = $avarda_order['b2C']['step']['current'];
 			} elseif ( 'B2B' === $avarda_order['mode'] ) {
-				$aco_state = $avarda_order['b2B']['step']['current'];
+				$aco_step = $avarda_order['b2B']['step']['current'];
 			}
 
 			// check if session TimedOut.
-			if ( 'TimedOut' === $aco_state ) {
+			if ( 'TimedOut' === $aco_step ) {
 				ACO_Logger::log( 'Avarda session TimedOut in process payment handler. Clearing Avarda session and reloading the cehckout page. Woo order ID: ' . $order_id . '. Avarda purchase ID: ' . $avarda_purchase_id );
 				return false;
 			}

--- a/classes/class-aco-order-management.php
+++ b/classes/class-aco-order-management.php
@@ -197,14 +197,14 @@ class ACO_Order_Management {
 		}
 
 		// Check if B2C or B2B.
-		$aco_state = '';
+		$aco_step = '';
 		if ( 'B2C' === $avarda_order_tmp['mode'] ) {
-			$aco_state = $avarda_order_tmp['b2C']['step']['current'];
+			$aco_step = $avarda_order_tmp['b2C']['step']['current'];
 		} elseif ( 'B2B' === $avarda_order_tmp['mode'] ) {
-			$aco_state = $avarda_order_tmp['b2B']['step']['current'];
+			$aco_step = $avarda_order_tmp['b2B']['step']['current'];
 		}
 
-		if ( 'Completed' === $aco_state ) {
+		if ( 'Completed' === $aco_step ) {
 			$refund_order_id = ACO_Helper_Create_Refund_Data::get_refunded_order( $order_id );
 			$refunded_items  = ACO_Helper_Create_Refund_Data::create_refund_data( $order_id, $refund_order_id, $amount, $reason );
 			$avarda_order    = ACO_WC()->api->request_return_order( $order_id, $refunded_items );
@@ -280,14 +280,14 @@ class ACO_Order_Management {
 		}
 
 		// Check if B2C or B2B.
-		$aco_state = '';
+		$aco_step = '';
 		if ( 'B2C' === $avarda_order_tmp['mode'] ) {
-			$aco_state = $avarda_order_tmp['b2C']['step']['current'];
+			$aco_step = $avarda_order_tmp['b2C']['step']['current'];
 		} elseif ( 'B2B' === $avarda_order_tmp['mode'] ) {
-			$aco_state = $avarda_order_tmp['b2B']['step']['current'];
+			$aco_step = $avarda_order_tmp['b2B']['step']['current'];
 		}
 
-		if ( 'Completed' === $aco_state ) {
+		if ( 'Completed' === $aco_step ) {
 			$avarda_order = ACO_WC()->api->request_refund_order( $order_id );
 			if ( is_wp_error( $avarda_order ) ) {
 				// If error save error message and return false.

--- a/includes/aco-functions.php
+++ b/includes/aco-functions.php
@@ -646,3 +646,24 @@ function aco_get_payment_state( $avarda_payment ) {
 	}
 	return $aco_state;
 }
+
+/**
+ * Returns approved Avarda payment steps where it is ok to send update requests.
+ *
+ * @return array Approved payment steps.
+ */
+function aco_payment_steps_approved_for_update_request() {
+	return array(
+		'EmailZipEntry',
+		'AmountSelection',
+		'PhoneNumberEntry',
+		'PhoneNumberEntryForKnownCustomer',
+		'Initialized',
+		'PersonalInfo',
+		'PersonalInfoWithoutSsn',
+		'SsnEntry',
+		'EnterCompanyInfo',
+		'CompanyAddressInfo',
+		'CompanyAddressInfoWithoutSsn',
+	);
+}

--- a/includes/aco-functions.php
+++ b/includes/aco-functions.php
@@ -106,9 +106,9 @@ function aco_wc_initialize_or_update_order() {
 		}
 
 		// Get payment status.
-		$aco_state = aco_get_payment_state( $avarda_payment );
+		$aco_step = aco_get_payment_step( $avarda_payment );
 
-		switch ( $aco_state ) {
+		switch ( $aco_step ) {
 			case 'Completed':
 				// Payment already completed in Avarda. Let's redirect the customer to the thankyou/confirmation page.
 				$order_id = aco_get_order_id_by_purchase_id( $avarda_purchase_id );
@@ -172,11 +172,11 @@ function aco_wc_initialize_or_update_order_from_wc_order( $order_id ) {
 		}
 
 		// Get payment status.
-		$aco_state = aco_get_payment_state( $avarda_payment );
+		$aco_step = aco_get_payment_step( $avarda_payment );
 
-		ACO_Logger::log( sprintf( 'Checking session for %s|%s (Avarda ID: %s). Session state: %s. Trying to initialize new or updating existing checkout session.', $order_id, $order->get_order_key(), $avarda_purchase_id, $aco_state ) );
+		ACO_Logger::log( sprintf( 'Checking session for %s|%s (Avarda ID: %s). Session state: %s. Trying to initialize new or updating existing checkout session.', $order_id, $order->get_order_key(), $avarda_purchase_id, $aco_step ) );
 
-		switch ( $aco_state ) {
+		switch ( $aco_step ) {
 			case 'Completed':
 				// Payment already completed in Avarda. Let's redirect the customer to the thankyou/confirmation page.
 				if ( is_object( $order ) ) {
@@ -276,14 +276,14 @@ function aco_confirm_avarda_order( $order_id = null, $avarda_purchase_id ) {
 		do_action( 'aco_wc_confirm_avarda_order', $order_id, $avarda_order );
 
 		// Check if B2C or B2B.
-		$aco_state = '';
+		$aco_step = '';
 		if ( 'B2C' === $avarda_order['mode'] ) {
-			$aco_state = $avarda_order['b2C']['step']['current'];
+			$aco_step = $avarda_order['b2C']['step']['current'];
 		} elseif ( 'B2B' === $avarda_order['mode'] ) {
-			$aco_state = $avarda_order['b2B']['step']['current'];
+			$aco_step = $avarda_order['b2B']['step']['current'];
 		}
 
-		if ( 'Completed' === $aco_state ) {
+		if ( 'Completed' === $aco_step ) {
 			ACO_WC()->api->request_update_order_reference( $avarda_purchase_id, $order_id ); // Update order reference.
 			// Payment complete and set transaction id.
 			// translators: Avarda purchase ID.
@@ -637,14 +637,14 @@ function aco_get_jwt_token_from_session() {
  * @param array $avarda_payment Avarda payment session.
  * @return string The payment state.
  */
-function aco_get_payment_state( $avarda_payment ) {
-	$aco_state = '';
+function aco_get_payment_step( $avarda_payment ) {
+	$aco_step = '';
 	if ( 'B2C' === $avarda_payment['mode'] ) {
-		$aco_state = $avarda_payment['b2C']['step']['current'];
+		$aco_step = $avarda_payment['b2C']['step']['current'];
 	} elseif ( 'B2B' === $avarda_payment['mode'] ) {
-		$aco_state = $avarda_payment['b2B']['step']['current'];
+		$aco_step = $avarda_payment['b2B']['step']['current'];
 	}
-	return $aco_state;
+	return $aco_step;
 }
 
 /**


### PR DESCRIPTION
* Change logic so update requests only will be triggered if step is one ot the approved steps (available in `aco_payment_steps_approved_for_update_request` function). Previous the logic where the other way around (we did not trigger update request if step was xx).
* Add this update check also when the checkout page is rendered (in `aco_wc_initialize_or_update_order` and `aco_wc_initialize_or_update_order_from_wc_order` function).