### PR TITLE
Hotfix for order query on confirmation step

### DIFF
--- a/classes/class-aco-callbacks.php
+++ b/classes/class-aco-callbacks.php
@@ -43,13 +43,14 @@ class ACO_Callbacks {
 			exit;
 		}
 
-		ACO_Logger::log( 'Notification callback hit for Avarda purchase ID: ' . $purchase_id . '. WC order ID: ' . $order->get_id() );
-
 		if ( ! is_object( $order ) ) {
 			ACO_Logger::log( 'Aborting notification callback for Purchase ID ' . $purchase_id . '. No WooCommerce order found.' );
 			header( 'HTTP/1.1 200 OK' );
 			exit;
 		}
+
+		ACO_Logger::log( 'Notification callback hit for Avarda purchase ID: ' . $purchase_id . '. WC order ID: ' . $order->get_id() );
+
 		// Maybe abort the callback (if the order already has been processed in Woo).
 		if ( ! empty( $order->get_date_paid() ) ) {
 			ACO_Logger::log( 'Aborting notification callback. Order ' . $order->get_order_number() . ' (order ID ' . $order->get_id() . ') already processed.' );

--- a/classes/class-aco-confirmation.php
+++ b/classes/class-aco-confirmation.php
@@ -50,36 +50,28 @@ class ACO_Confirmation {
 		$order_key          = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$order_id           = filter_input( INPUT_GET, 'wc_order_id', FILTER_SANITIZE_NUMBER_INT );
 
-		// Return if we dont have our parameters set.
+		// Return if we don't have our parameters set.
 		if ( empty( $aco_confirm ) || empty( $avarda_purchase_id ) ) {
 			return;
 		}
 
 		$order = wc_get_order( $order_id );
-		$order = empty( $order ) || $order->get_meta( '_wc_avarda_purchase_id' ) !== $avarda_purchase_id ? false : $order;
+		$order = empty( $order ) ? false : $order;
+
 		if ( empty( $order ) ) {
 			// Find relevant order in Woo.
-			$orders = wc_get_orders(
-				array(
-					'meta_query' => array(
-						'meta_key'   => '_wc_avarda_purchase_id',
-						'meta_value' => $avarda_purchase_id,
-						'limit'      => 1,
-						'orderby'    => 'date',
-						'order'      => 'DESC',
-						'compare'    => '=',
-					),
-				)
-			);
-
-			$order = reset( $orders );
-
+			$order = aco_get_order_by_purchase_id( $avarda_purchase_id );
 		}
 
 		if ( empty( $order ) ) {
 			$order_key = sanitize_text_field( $order_key );
 			$order_id  = wc_get_order_id_by_order_key( $order_key );
 			$order     = wc_get_order( $order_id );
+		}
+
+		// Verify the meta data after we get an order, to ensure that we don't process a wrong order.
+		if ( $order->get_meta( '_wc_avarda_purchase_id' ) !== $avarda_purchase_id ) {
+			$order = false;
 		}
 
 		if ( ! $order ) {

--- a/includes/aco-functions.php
+++ b/includes/aco-functions.php
@@ -64,7 +64,6 @@ function aco_wc_initialize_payment() {
 	WC()->session->set( 'aco_wc_cart_contains_subscription', aco_get_wc_cart_contains_subscription() );
 	WC()->session->set( 'aco_last_update_hash', WC()->cart->get_cart_hash() );
 	return $avarda_payment;
-
 }
 
 /**
@@ -285,8 +284,8 @@ function aco_confirm_avarda_order( $order_id, $avarda_purchase_id ) {
 		// Get the Avarda order.
 		$avarda_order = ACO_WC()->api->request_get_payment( $avarda_purchase_id );
 
-		// Populate wc order address.
-		aco_populate_wc_order( $order, $avarda_order );
+		// Set Avarda payment method title.
+		aco_set_payment_method_title( $order, $avarda_order );
 
 		// Let other plugins hook into this sequence.
 		do_action( 'aco_wc_confirm_avarda_order', $order_id, $avarda_order );
@@ -414,7 +413,6 @@ function aco_populate_wc_order( $order, $avarda_order ) {
 
 	// Save order.
 	$order->save();
-
 }
 
 function aco_format_address_data( $avarda_order ) {


### PR DESCRIPTION
* Fix - Fixed a incorrect meta query during the confirmation step if the order id was missing from the url.
* Fix - Improved checks before we confirm an order to ensure the payment id from Avarda matches the stored payment id in the order.
* Fix - Fixed a potential fatal error when handling a callback from Avarda, that happened due to logging the order id before ensuring we had an order.