### PR TITLE
Order management hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+/vendor

--- a/classes/class-aco-order-management.php
+++ b/classes/class-aco-order-management.php
@@ -36,7 +36,7 @@ class ACO_Order_Management {
 			return;
 		}
 
-		// Check Avarda settings to see if we have the ordermanagement enabled.
+		// Check Avarda settings to see if we have the order management enabled.
 		$avarda_settings  = get_option( 'woocommerce_aco_settings' );
 		$order_management = 'yes' === $avarda_settings['order_management'] ? true : false;
 		if ( ! $order_management ) {
@@ -51,10 +51,11 @@ class ACO_Order_Management {
 		$subscription = $this->check_if_subscription( $order );
 
 		// Check if we have a purchase id.
-		$purchase_id = $order->get_meta( '_wc_avarda_purchase_id', true );
+		$purchase_id = $order->get_meta( '_wc_avarda_purchase_id', true ) ?? $order->get_transaction_id() ?? '';
 		if ( empty( $purchase_id ) ) {
 			$note = __( 'Avarda Checkout reservation could not be cancelled. Missing Avarda purchase id.', 'avarda-checkout-for-woocommerce' );
 			$order->update_status( 'on-hold', $note );
+			do_action( 'aco_om_failed', 'cancel', $note, $order );
 			return;
 		}
 
@@ -64,7 +65,7 @@ class ACO_Order_Management {
 			return;
 		}
 
-		// TODO: Should we do different request if order is subcription?
+		// TODO: Should we do different request if order is subscription?
 		// Cancel order.
 		$avarda_order = ( $subscription ) ? ACO_WC()->api->request_cancel_order( $order_id ) : ACO_WC()->api->request_cancel_order( $order_id );
 
@@ -76,6 +77,7 @@ class ACO_Order_Management {
 			$text    = __( 'Avarda API Error on Avarda cancel order: ', 'avarda-checkout-for-woocommerce' ) . '%s %s';
 			$note    = sprintf( $text, $code, $message );
 			$order->update_status( 'on-hold', $note );
+			do_action( 'aco_om_failed', 'cancel', $note, $order );
 		} else {
 			// Add time stamp, used to prevent duplicate activations for the same order.
 			$order->update_meta_data( '_avarda_reservation_cancelled', current_time( 'mysql' ) );
@@ -116,10 +118,11 @@ class ACO_Order_Management {
 		}
 
 		// Check if we have a purchase id.
-		$purchase_id = $order->get_meta( '_wc_avarda_purchase_id', true );
+		$purchase_id = $order->get_meta( '_wc_avarda_purchase_id', true ) ?? $order->get_transaction_id() ?? '';
 		if ( empty( $purchase_id ) ) {
 			$note = __( 'Avarda Checkout reservation could not be activated. Missing Avarda purchase id.', 'avarda-checkout-for-woocommerce' );
 			$order->update_status( 'on-hold', $note );
+			do_action( 'aco_om_failed', 'activate', $note, $order );
 			return;
 		}
 
@@ -129,7 +132,7 @@ class ACO_Order_Management {
 			return;
 		}
 
-		// TODO: Should we do different request if order is subcription?
+		// TODO: Should we do different request if order is subscription?
 		// Activate order.
 		$avarda_order = ( $subscription ) ? ACO_WC()->api->request_activate_order( $order_id ) : ACO_WC()->api->request_activate_order( $order_id );
 
@@ -141,6 +144,7 @@ class ACO_Order_Management {
 			$text    = __( 'Avarda API Error on Avarda activate order: ', 'avarda-checkout-for-woocommerce' ) . '%s %s';
 			$note    = sprintf( $text, $code, $message );
 			$order->update_status( 'on-hold', $note );
+			do_action( 'aco_om_failed', 'activate', $note, $order );
 		} else {
 			// Add time stamp, used to prevent duplicate activations for the same order.
 			$order->update_meta_data( '_avarda_reservation_activated', current_time( 'mysql' ) );
@@ -202,7 +206,7 @@ class ACO_Order_Management {
 		$subscription = $this->check_if_subscription( $order );
 
 		// Get the Avarda order.
-		// TODO: Should we do different request if order is subcription?
+		// TODO: Should we do different request if order is subscription?
 		$avarda_order_tmp = ( $subscription ) ? ACO_WC()->api->request_get_payment( $purchase_id, true ) : ACO_WC()->api->request_get_payment( $purchase_id, true );
 		if ( is_wp_error( $avarda_order_tmp ) ) {
 			// If error save error message.
@@ -285,7 +289,7 @@ class ACO_Order_Management {
 
 		$subscription = $this->check_if_subscription( $order );
 
-		// TODO: Should we do different request if order is subcription?
+		// TODO: Should we do different request if order is subscription?
 		$avarda_order_tmp = ( $subscription ) ? ACO_WC()->api->request_get_payment( $purchase_id, true ) : ACO_WC()->api->request_get_payment( $purchase_id, true );
 		if ( is_wp_error( $avarda_order_tmp ) ) {
 			// If error save error message.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "php-stubs/woocommerce-stubs": "^8.5"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,110 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "29ff10555e81abd99d7a4daae77ac4cc",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "php-stubs/woocommerce-stubs",
+            "version": "v8.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/woocommerce-stubs.git",
+                "reference": "d2ea3610bab1e51b81c745bfdc00eeae3da8454d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/d2ea3610bab1e51b81c745bfdc00eeae3da8454d",
+                "reference": "d2ea3610bab1e51b81c745bfdc00eeae3da8454d",
+                "shasum": ""
+            },
+            "require": {
+                "php-stubs/wordpress-stubs": "^5.3 || ^6.0"
+            },
+            "require-dev": {
+                "php": "~7.1 || ~8.0",
+                "php-stubs/generator": "^0.8.0"
+            },
+            "suggest": {
+                "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WooCommerce function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/woocommerce-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "woocommerce",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v8.5.1"
+            },
+            "time": "2024-01-15T19:51:26+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "6d6063cf9464a306ca2a0529705d41312b08500b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/6d6063cf9464a306ca2a0529705d41312b08500b",
+                "reference": "6d6063cf9464a306ca2a0529705d41312b08500b",
+                "shasum": ""
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^4.13",
+                "php": "^7.4 || ~8.0.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^5.3",
+                "phpstan/phpstan": "^1.10.12",
+                "phpunit/phpunit": "^9.5",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^0.8"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.4.1"
+            },
+            "time": "2023-11-10T00:33:47+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
+}

--- a/includes/aco-functions.php
+++ b/includes/aco-functions.php
@@ -300,12 +300,18 @@ function aco_confirm_avarda_order( $order_id, $avarda_purchase_id ) {
 
 		if ( 'Completed' === $aco_step ) {
 			ACO_WC()->api->request_update_order_reference( $avarda_purchase_id, $order_id ); // Update order reference.
-			// Payment complete and set transaction id.
-			// translators: Avarda purchase ID.
-			$note = sprintf( __( 'Payment via Avarda Checkout. Purchase ID: %s', 'avarda-checkout-for-woocommerce' ), sanitize_text_field( $avarda_order['purchaseId'] ) );
-			$order->add_order_note( $note );
-			$order->payment_complete( $avarda_purchase_id );
-			do_action( 'aco_wc_payment_complete', $order_id, $avarda_order );
+
+			// Check order totals.
+			if ( aco_check_order_totals( $order, $avarda_order ) ) {
+				// Payment complete and set transaction id.
+				// translators: Avarda purchase ID.
+				$note = sprintf( __( 'Payment via Avarda Checkout. Purchase ID: %s', 'avarda-checkout-for-woocommerce' ), sanitize_text_field( $avarda_order['purchaseId'] ) );
+				$order->add_order_note( $note );
+				$order->payment_complete( $avarda_purchase_id );
+				do_action( 'aco_wc_payment_complete', $order_id, $avarda_order );
+			} else {
+				$order->update_status( 'on-hold' );
+			}
 		}
 	}
 }
@@ -741,4 +747,31 @@ function aco_get_wc_cart_contains_subscription() {
 		$contains_subscription = true;
 	}
 	return apply_filters( 'aco_wc_cart_contains_subscription', $contains_subscription );
+}
+
+/**
+ * Check order totals
+ *
+ * @param WC_Order $order The WooCommerce order.
+ * @param array    $avarda_order The Collector order.
+ *
+ * @return bool TRUE If the WC and Avarda total amounts match, otherwise FALSE.
+ */
+function aco_check_order_totals( $order, $avarda_order ) {
+	// Check order total and compare it with Woo.
+	$woo_order_total    = intval( round( $order->get_total() * 100, 2 ) );
+	$avarda_order_total = intval( round( $avarda_order['totalPrice'] * 100, 2 ) );
+	if ( ( $woo_order_total > $avarda_order_total && ( $woo_order_total - $avarda_order_total ) > 3 ) ||
+		( $avarda_order_total > $woo_order_total && ( $avarda_order_total - $woo_order_total ) > 3 )
+	) {
+
+		// Translators: Woo order number, Woo order total, Avarda order total.
+		$note = sprintf( __( 'Order total mismatch in order number: %1$s. Woo order total: %2$s, Avarda order total: %3$s (converted to minor units).', 'avarda-checkout-for-woocommerce' ), $order->get_order_number(), $woo_order_total, $avarda_order_total );
+		ACO_Logger::log( $note );
+		$order->add_order_note( $note );
+		do_action( 'aco_confirm_order_failed', 'order_total_mismatch', $note, $order );
+		return false;
+	}
+
+	return true;
 }


### PR DESCRIPTION
Adds `aco_om_failed` hook so other plugins can listen to and take action if activation and cancelation logic fails.