### PR TITLE
Small tweaks to delete old session data in Woo order if new purchase id is created for customer

### DIFF
--- a/classes/class-aco-assets.php
+++ b/classes/class-aco-assets.php
@@ -204,10 +204,7 @@ class ACO_Assets {
 			// Creates a session and store it to order if we don't have a previous one or if it has expired.
 			$avarda_jwt_expired_time = $order->get_meta( '_wc_avarda_expiredUtc', true );
 			if ( empty( $avarda_jwt_expired_time ) || strtotime( $avarda_jwt_expired_time ) < time() ) {
-				$order->delete_meta_data( '_wc_avarda_purchase_id' );
-				$order->delete_meta_data( '_wc_avarda_jwt' );
-				$order->delete_meta_data( '_wc_avarda_expiredUtc' );
-				$order->save();
+				aco_delete_avarda_meta_data_from_order( $order );
 				aco_wc_initialize_or_update_order_from_wc_order( $order_id );
 			}
 		} else {

--- a/classes/class-aco-gateway.php
+++ b/classes/class-aco-gateway.php
@@ -154,7 +154,8 @@ class ACO_Gateway extends WC_Payment_Gateway {
 			ACO_Logger::log( sprintf( 'Processing order %s|%s (Avarda ID: %s) failed for some reason. Clearing session.', $order_id, $order->get_order_key(), $avarda_purchase_id ) );
 
 			aco_wc_unset_sessions();
-			$order->delete_meta_data( '_wc_avarda_purchase_id' );
+			aco_delete_avarda_meta_data_from_order( $order );
+	
 			$order->set_transaction_id( '' );
 			$order->save();
 			return array(


### PR DESCRIPTION
* Delete `_wc_avarda_jwt` & `_wc_avarda_expiredUtc` in Woo order when deleting `_wc_avarda_purchase_id` (if Avarda session expires and a new one is created).
*  Use new function `aco_delete_avarda_meta_data_from_order` do avoid duplicate code. 