### PR TITLE
Add support for international checkout

### DIFF
--- a/avarda-checkout-for-woocommerce.php
+++ b/avarda-checkout-for-woocommerce.php
@@ -104,6 +104,20 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 		public $cart_page;
 
 		/**
+		 * Customer helper class instance.
+		 *
+		 * @var ACO_Helper_Customer $customer
+		 */
+		public $customer;
+
+		/**
+		 * The checkout flow.
+		 *
+		 * @var string $checkout_flow
+		 */
+		public $checkout_flow;
+
+		/**
 		 * The reference the *Singleton* instance of this class.
 		 *
 		 * @var $instance
@@ -140,7 +154,7 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 		 * @return void
 		 */
 		private function __clone() {
-			wc_doing_it_wrong( __FUNCTION__, __( 'Nope' ), '1.0' );
+			wc_doing_it_wrong( __FUNCTION__, __( 'Nope', 'avarda-checkout-for-woocommerce' ), '1.0' );
 		}
 		/**
 		 * Public unserialize method to prevent unserializing of the *Singleton*
@@ -149,7 +163,7 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 		 * @return void
 		 */
 		public function __wakeup() {
-			wc_doing_it_wrong( __FUNCTION__, __( 'Nope' ), '1.0' );
+			wc_doing_it_wrong( __FUNCTION__, __( 'Nope', 'avarda-checkout-for-woocommerce' ), '1.0' );
 		}
 
 		/**

--- a/avarda-checkout-for-woocommerce.php
+++ b/avarda-checkout-for-woocommerce.php
@@ -187,7 +187,7 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 			$this->include_files();
 
 			// Delete transient when aco settings is saved.
-			add_action( 'woocommerce_update_options_checkout_aco', array( $this, 'aco_delete_transients' ) );
+			add_action( 'woocommerce_update_options_checkout_aco', array( $this, 'delete_all_transients' ) );
 
 			// Register the shipping method with WooCommerce.
 			add_filter( 'woocommerce_shipping_methods', ACO_Shipping::class . '::register' );
@@ -258,14 +258,17 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 
 
 		/**
-		 * Delete transients when ACO settings is saved.
+		 * Delete all possible transients when saving the settings.
 		 *
 		 * @return void
 		 */
-		public function aco_delete_transients() {
-			// Need to clear transients if credentials is changed.
-			delete_transient( 'aco_auth_token' );
-			delete_transient( 'aco_currency' );
+		public function delete_all_transients() {
+			$currencies = array( 'SEK', 'NOK', 'DKK', 'EUR' );
+
+			foreach ( $currencies as $currency ) {
+				$name = aco_get_transient_name( $currency );
+				delete_transient( $name );
+			}
 		}
 
 		/**

--- a/classes/class-aco-gateway.php
+++ b/classes/class-aco-gateway.php
@@ -150,12 +150,12 @@ class ACO_Gateway extends WC_Payment_Gateway {
 				'redirect_url' => $confirmation_url,
 			);
 		} else {
-			// Something went wrong. Unset sessions and remove previos purchase id from order.
+			// Something went wrong. Unset sessions and remove previous purchase id from order.
 			ACO_Logger::log( sprintf( 'Processing order %s|%s (Avarda ID: %s) failed for some reason. Clearing session.', $order_id, $order->get_order_key(), $avarda_purchase_id ) );
 
 			aco_wc_unset_sessions();
 			aco_delete_avarda_meta_data_from_order( $order );
-	
+
 			$order->set_transaction_id( '' );
 			$order->save();
 			return array(
@@ -183,7 +183,6 @@ class ACO_Gateway extends WC_Payment_Gateway {
 			'result'   => 'success',
 			'redirect' => $pay_url,
 		);
-
 	}
 
 	/**
@@ -327,7 +326,6 @@ class ACO_Gateway extends WC_Payment_Gateway {
 
 		}
 	}
-
 }
 
 /**

--- a/classes/requests/checkout/post/class-aco-request-initialize-payment.php
+++ b/classes/requests/checkout/post/class-aco-request-initialize-payment.php
@@ -44,30 +44,27 @@ class ACO_Request_Initialize_Payment extends ACO_Request {
 	 * @return array
 	 */
 	public function get_body( $order_id ) {
-
 		$request_body = array(
-			'checkoutSetup' => ACO_WC()->checkout_setup->get_checkout_setup( $order_id ),
+			'checkoutSetup' => ACO_WC()->checkout_setup->get_checkout_setup( $order_id, $this->international ),
 		);
+
+		$b2b   = false;
+		$order = null;
+
+		// Set order specific data.
 		if ( $order_id ) {
 			$order                 = wc_get_order( $order_id );
 			$request_body['items'] = ACO_WC()->order_items->get_order_items( $order_id );
 			$request_body['extraIdentifiers']['orderReference'] = (string) $order->get_order_number();
-			// Add customer address if it exist.
-			if ( $order->get_billing_company() ) {
-				$customer_address = ACO_WC()->customer->get_b2b_customer( $order_id );
-				if ( ! empty( $customer_address ) ) {
-					$request_body['b2B'] = $customer_address;
-				}
-			} else {
-				$customer_address = ACO_WC()->customer->get_b2c_customer( $order_id );
-				if ( ! empty( $customer_address ) ) {
-					$request_body['b2C'] = $customer_address;
-				}
-			}
-		} else {
+			$b2b = ! empty( $order->get_billing_company() );
+		} else { // Set cart specific data.
 			$request_body['items']            = ACO_WC()->cart_items->get_cart_items();
 			$request_body['shippingSettings'] = ACO_WC()->cart_items->get_shipping_settings();
+			$b2b                              = ! empty( WC()->customer->get_billing_company() );
 		}
+
+		// Add customer details to the request body.
+		$request_body[ $b2b ? 'b2B' : 'b2C' ] = ACO_WC()->customer->get_customer( $order, $b2b );
 
 		return apply_filters( 'aco_create_args', $request_body, $order_id );
 	}

--- a/classes/requests/class-aco-request.php
+++ b/classes/requests/class-aco-request.php
@@ -53,9 +53,23 @@ class ACO_Request {
 	/**
 	 * The request environment.
 	 *
-	 * @var $enviroment
+	 * @var $environment
 	 */
 	public $environment;
+
+	/**
+	 * If the request is authenticated.
+	 *
+	 * @var boolean $auth
+	 */
+	public $auth = false;
+
+	/**
+	 * If the request if using international credentials.
+	 *
+	 * @var boolean $international
+	 */
+	public $international = false;
 
 	/**
 	 * Class constructor
@@ -90,7 +104,7 @@ class ACO_Request {
 	}
 
 	/**
-	 * Sets the enviroment.
+	 * Sets the environment.
 	 *
 	 * @return void
 	 */
@@ -113,31 +127,75 @@ class ACO_Request {
 	 */
 	public function set_environment_variables() {
 		$this->avarda_settings = get_option( 'woocommerce_aco_settings' );
+		$this->testmode        = $this->avarda_settings['testmode'];
 
-		switch ( get_woocommerce_currency() ) {
-			case 'SEK':
-				$this->client_id     = $this->avarda_settings['merchant_id_se'];
-				$this->client_secret = $this->avarda_settings['api_key_se'];
-				break;
-			case 'NOK':
-				$this->client_id     = $this->avarda_settings['merchant_id_no'];
-				$this->client_secret = $this->avarda_settings['api_key_no'];
-				break;
-			case 'DKK':
-				$this->client_id     = $this->avarda_settings['merchant_id_dk'];
-				$this->client_secret = $this->avarda_settings['api_key_dk'];
-				break;
-			case 'EUR':
-				$this->client_id     = $this->avarda_settings['merchant_id_fi'];
-				$this->client_secret = $this->avarda_settings['api_key_fi'];
-				break;
-			default:
-				$this->client_id     = $this->avarda_settings['merchant_id_se'];
-				$this->client_secret = $this->avarda_settings['api_key_se'];
-				break;
-		}
-		$this->testmode = $this->avarda_settings['testmode'];
+		// Get the client id and secret based on the country.
+		$credential_country = $this->get_credential_country();
+		$credentials        = $this->get_credentials( $credential_country );
+
+		// Set the client id and secret and apply filters to allow for customization.
+		$this->client_id     = apply_filters( 'aco_client_id', $credentials['client_id'] ?? '', $this->international );
+		$this->client_secret = apply_filters( 'aco_client_secret', $credentials['client_secret'] ?? '', $this->international );
+
 		$this->base_url = ( 'yes' === $this->testmode ) ? AVARDA_CHECKOUT_TEST_ENV : AVARDA_CHECKOUT_LIVE_ENV;
+	}
+
+	/**
+	 * Get the country to use when getting the credentials from the settings.
+	 *
+	 * @param WC_Order|int|null $order The WooCommerce order, order id or null if we are using the cart.
+	 *
+	 * @return string The country code.
+	 */
+	public function get_credential_country( $order = null ) {
+		if ( ! $order instanceof WC_Order ) {
+			$order = wc_get_order( $order );
+		}
+
+		$currency         = $order ? $order->get_currency() : get_woocommerce_currency();
+		$currency_country = array(
+			'SEK' => 'se',
+			'NOK' => 'no',
+			'DKK' => 'dk',
+			'EUR' => 'fi',
+		);
+
+		return $currency_country[ $currency ] ?? ''; // Default to se if the currency is not a supported currency.
+	}
+
+	/**
+	 * Get the credentials to use for the country.
+	 *
+	 * @param string $country The country code.
+	 *
+	 * @return array The credentials.
+	 */
+	public function get_credentials( $country ) {
+		$client_id     = '';
+		$client_secret = '';
+
+		if ( isset( $this->avarda_settings[ 'merchant_id_' . $country ] ) && isset( $this->avarda_settings[ 'api_key_' . $country ] ) ) {
+			$client_id     = $this->avarda_settings[ 'merchant_id_' . $country ];
+			$client_secret = $this->avarda_settings[ 'api_key_' . $country ];
+		}
+
+		// If the client id or secret is still empty, use the international credentials.
+		if ( empty( $client_id ) || empty( $client_secret ) ) {
+			$client_id           = $this->avarda_settings['merchant_id_int'] ?? null;
+			$client_secret       = $this->avarda_settings['api_key_int'] ?? null;
+			$this->international = true;
+		}
+
+		return apply_filters(
+			'aco_credentials',
+			array(
+				'client_id'     => $client_id,
+				'client_secret' => $client_secret,
+			),
+			$country,
+			$this->international,
+			$this->testmode
+		);
 	}
 
 	/**

--- a/classes/requests/helpers/class-aco-helper-checkout-setup.php
+++ b/classes/requests/helpers/class-aco-helper-checkout-setup.php
@@ -16,10 +16,12 @@ class ACO_Helper_Checkout_Setup {
 	/**
 	 * Gets checkout setup.
 	 *
-	 * @param int $order_id The WooCommerce order id.
+	 * @param int  $order_id The WooCommerce order id.
+	 * @param bool $is_international Whether the order is international or not.
+	 *
 	 * @return array Formatted checkout setup.
 	 */
-	public function get_checkout_setup( $order_id = null ) {
+	public function get_checkout_setup( $order_id = null, $is_international = false ) {
 
 		$avarda_settings = get_option( 'woocommerce_aco_settings' );
 		$age_validation  = $avarda_settings['age_validation'] ?? '';
@@ -52,6 +54,11 @@ class ACO_Helper_Checkout_Setup {
 		// Age validation.
 		if ( ! empty( $age_validation ) ) {
 			$checkout_setup['ageValidation'] = $age_validation;
+		}
+
+		// Set the international properties to the checkout setup if the order is international.
+		if ( $is_international ) {
+			$checkout_setup = $this->set_international_properties( $checkout_setup );
 		}
 
 		return $checkout_setup;
@@ -99,4 +106,18 @@ class ACO_Helper_Checkout_Setup {
 		return apply_filters( 'aco_wc_terms_url', $terms_url );
 	}
 
+	/**
+	 * Set international properties.
+	 *
+	 * @param array $checkout_setup The checkout setup.
+	 *
+	 * @return array
+	 */
+	private function set_international_properties( $checkout_setup ) {
+		$checkout_setup['enableCountrySelector'] = true;
+		$checkout_setup['invoicingCountries']    = array_keys( WC()->countries->get_allowed_countries() );
+		$checkout_setup['deliveryCountries']     = array_keys( WC()->countries->get_shipping_countries() );
+
+		return $checkout_setup;
+	}
 }

--- a/includes/aco-form-fields.php
+++ b/includes/aco-form-fields.php
@@ -164,5 +164,22 @@ $settings = array(
 		'default'  => '',
 		'desc_tip' => true,
 	),
+	// International.
+	'credentials_international'  => array(
+		'title' => 'API Credentials International',
+		'type'  => 'title',
+	),
+	'merchant_id_int'            => array(
+		'title'    => __( 'Client ID', 'avarda-checkout-for-woocommerce' ),
+		'type'     => 'text',
+		'default'  => '',
+		'desc_tip' => true,
+	),
+	'api_key_int'                => array(
+		'title'    => __( 'Client Secret', 'avarda-checkout-for-woocommerce' ),
+		'type'     => 'text',
+		'default'  => '',
+		'desc_tip' => true,
+	),
 );
 return apply_filters( 'aco_settings', $settings );


### PR DESCRIPTION
* Feature - Adds support for international checkout using the international credentials setting fields. If a currency the customer is using does not have their own credentials in Avarda the international credentials will be used instead.
* Feature - Adds filters for the credentials used in the requests. These are `aco_credentials`, `aco_client_id` and `aco_client_secret`.
* Enhancement - Auth tokens created for the requests are now stored individually based on currency as transients to prevent new tokens being generated each time a new currency is used. Should reduce the amount of requests made on stores using multiple currencies with Avarda.
* Fix - Fixed PHP 8.2 deprecation warnings.