### PR TITLE
Fix issue with expired token after order has been created in WooCommerce

### DIFF
--- a/avarda-checkout-for-woocommerce.php
+++ b/avarda-checkout-for-woocommerce.php
@@ -104,6 +104,20 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 		public $cart_page;
 
 		/**
+		 * Customer helper class instance.
+		 *
+		 * @var ACO_Helper_Customer $customer
+		 */
+		public $customer;
+
+		/**
+		 * The checkout flow.
+		 *
+		 * @var string $checkout_flow
+		 */
+		public $checkout_flow;
+
+		/**
 		 * The reference the *Singleton* instance of this class.
 		 *
 		 * @var $instance
@@ -140,7 +154,7 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 		 * @return void
 		 */
 		private function __clone() {
-			wc_doing_it_wrong( __FUNCTION__, __( 'Nope' ), '1.0' );
+			wc_doing_it_wrong( __FUNCTION__, __( 'Nope', 'avarda-checkout-for-woocommerce' ), '1.0' );
 		}
 		/**
 		 * Public unserialize method to prevent unserializing of the *Singleton*
@@ -149,7 +163,7 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 		 * @return void
 		 */
 		public function __wakeup() {
-			wc_doing_it_wrong( __FUNCTION__, __( 'Nope' ), '1.0' );
+			wc_doing_it_wrong( __FUNCTION__, __( 'Nope', 'avarda-checkout-for-woocommerce' ), '1.0' );
 		}
 
 		/**

--- a/avarda-checkout-for-woocommerce.php
+++ b/avarda-checkout-for-woocommerce.php
@@ -187,7 +187,7 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 			$this->include_files();
 
 			// Delete transient when aco settings is saved.
-			add_action( 'woocommerce_update_options_checkout_aco', array( $this, 'aco_delete_transients' ) );
+			add_action( 'woocommerce_update_options_checkout_aco', array( $this, 'delete_all_transients' ) );
 
 			// Register the shipping method with WooCommerce.
 			add_filter( 'woocommerce_shipping_methods', ACO_Shipping::class . '::register' );
@@ -258,14 +258,17 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 
 
 		/**
-		 * Delete transients when ACO settings is saved.
+		 * Delete all possible transients when saving the settings.
 		 *
 		 * @return void
 		 */
-		public function aco_delete_transients() {
-			// Need to clear transients if credentials is changed.
-			delete_transient( 'aco_auth_token' );
-			delete_transient( 'aco_currency' );
+		public function delete_all_transients() {
+			$currencies = array( 'SEK', 'NOK', 'DKK', 'EUR' );
+
+			foreach ( $currencies as $currency ) {
+				$name = aco_get_transient_name( $currency );
+				delete_transient( $name );
+			}
 		}
 
 		/**

--- a/classes/class-aco-checkout.php
+++ b/classes/class-aco-checkout.php
@@ -130,7 +130,7 @@ class ACO_Checkout {
 		}
 
 		// Get the Avarda order from Avarda.
-		$avarda_order = ACO_WC()->session()->get_avarda_order();
+		$avarda_order = ACO_WC()->session()->get_avarda_payment();
 
 		// Check if we got a wp_error.
 		if ( is_wp_error( $avarda_order ) ) {

--- a/classes/class-aco-gateway.php
+++ b/classes/class-aco-gateway.php
@@ -150,12 +150,12 @@ class ACO_Gateway extends WC_Payment_Gateway {
 				'redirect_url' => $confirmation_url,
 			);
 		} else {
-			// Something went wrong. Unset sessions and remove previos purchase id from order.
+			// Something went wrong. Unset sessions and remove previous purchase id from order.
 			ACO_Logger::log( sprintf( 'Processing order %s|%s (Avarda ID: %s) failed for some reason. Clearing session.', $order_id, $order->get_order_key(), $avarda_purchase_id ) );
 
 			aco_wc_unset_sessions();
 			aco_delete_avarda_meta_data_from_order( $order );
-	
+
 			$order->set_transaction_id( '' );
 			$order->save();
 			return array(
@@ -183,7 +183,6 @@ class ACO_Gateway extends WC_Payment_Gateway {
 			'result'   => 'success',
 			'redirect' => $pay_url,
 		);
-
 	}
 
 	/**
@@ -327,7 +326,6 @@ class ACO_Gateway extends WC_Payment_Gateway {
 
 		}
 	}
-
 }
 
 /**

--- a/classes/class-aco-gateway.php
+++ b/classes/class-aco-gateway.php
@@ -13,6 +13,26 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Gateway class.
  */
 class ACO_Gateway extends WC_Payment_Gateway {
+	/**
+	 * Testmode.
+	 *
+	 * @var boolean
+	 */
+	public $testmode;
+
+	/**
+	 * Payment gateway icon.
+	 *
+	 * @var string
+	 */
+	public $payment_gateway_icon;
+
+	/**
+	 * Payment gateway icon max width.
+	 *
+	 * @var string
+	 */
+	public $payment_gateway_icon_max_width;
 
 	/**
 	 * Class constructor.
@@ -88,18 +108,38 @@ class ACO_Gateway extends WC_Payment_Gateway {
 	 * @return boolean
 	 */
 	public function is_available() {
-		if ( 'yes' === $this->enabled ) {
-			// Do checks here.
+		// Ensure that the Avarda Checkout gateway is enabled.
+		if ( 'yes' !== $this->enabled ) {
+			ACO_Logger::log( 'Avarda Checkout payment gateway is not enabled.', WC_Log_Levels::DEBUG );
+			return false;
+		}
 
-			// Avarda doesn't support 0 value subscriptions.
-			if ( class_exists( 'WC_Subscriptions_Cart' ) && ( WC_Subscriptions_Cart::cart_contains_subscription() || wcs_cart_contains_renewal() ) ) {
-				if ( 0 == round( WC()->cart->total, 2 ) ) { // phpcs:ignore
-					return false;
-				}
-			}
+		// If we are on an admin page, just return true.
+		if ( is_admin() ) {
 			return true;
 		}
-		return false;
+
+		// If we have an avarda session, ensure the currency matches the current currency for the store.
+		$avarda_payment = ACO_WC()->session()->get_avarda_payment();
+		if ( ! is_wp_error( $avarda_payment ) && ! empty( $avarda_payment ) ) {
+			// Ensure the currency matches the current currency for the store.
+			$payment_currency = $avarda_payment['checkoutSite']['currencyCode'] ?? '';
+			$wc_currency      = get_woocommerce_currency();
+			if ( strtoupper( $wc_currency ) !== strtoupper( $payment_currency ) ) {
+				ACO_Logger::log( 'Currency mismatch. The Avarda Checkout payment gateway is not available.', WC_Log_Levels::DEBUG );
+				return false;
+			}
+		}
+
+		// Avarda doesn't support 0 value subscriptions.
+		if ( class_exists( 'WC_Subscriptions_Cart' ) && ( WC_Subscriptions_Cart::cart_contains_subscription() || wcs_cart_contains_renewal() ) ) {
+			if ( 0 == round( WC()->cart->total, 2 ) ) { // phpcs:ignore
+				ACO_Logger::log( 'Subscription total is 0. The Avarda Checkout payment gateway is not available.', WC_Log_Levels::DEBUG );
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -209,29 +249,15 @@ class ACO_Gateway extends WC_Payment_Gateway {
 		// Get the Avarda order ID.
 		$order              = wc_get_order( $order_id );
 		$avarda_purchase_id = $this->get_avarda_purchase_id( $order );
-		$avarda_order       = ACO_WC()->api->request_get_payment( $avarda_purchase_id );
-		if ( is_wp_error( $avarda_order ) ) {
-			// Unset sessions.
-			ACO_Logger::log( 'Avarda GET request failed in process payment handler. Clearing Avarda session and reloading the checkout page. Woo order ID: ' . $order_id . '. Avarda purchase ID: ' . $avarda_purchase_id );
+		$avarda_order       = ACO_WC()->session()->get_avarda_payment();
+
+		if ( is_wp_error( $avarda_order ) || empty( $avarda_order ) ) {
+			$this->log_process_payment_get_error( $avarda_order, $order_id, $avarda_purchase_id );
 			return false;
 		}
 
 		if ( $order_id && $avarda_order ) {
-
-			// Get current status of Avarda session.
-			if ( 'B2C' === $avarda_order['mode'] ) {
-				$aco_step = $avarda_order['b2C']['step']['current'];
-			} elseif ( 'B2B' === $avarda_order['mode'] ) {
-				$aco_step = $avarda_order['b2B']['step']['current'];
-			}
-
-			// check if session TimedOut.
-			if ( 'TimedOut' === $aco_step ) {
-				ACO_Logger::log( 'Avarda session TimedOut in process payment handler. Clearing Avarda session and reloading the cehckout page. Woo order ID: ' . $order_id . '. Avarda purchase ID: ' . $avarda_purchase_id );
-				return false;
-			}
-
-			$purchase_id = sanitize_text_field( $avarda_order['purchaseId'] );
+			$purchase_id = sanitize_text_field( ACO_WC()->session()->get_purchase_id() );
 			$order->update_meta_data( '_wc_avarda_purchase_id', $purchase_id );
 			$order->set_transaction_id( $purchase_id );
 			$order->update_meta_data( '_wc_avarda_environment', $this->testmode ? 'test' : 'live' );
@@ -243,13 +269,39 @@ class ACO_Gateway extends WC_Payment_Gateway {
 			do_action( 'aco_wc_process_payment', $order_id, $avarda_order );
 
 			// Check that the transaction id got set correctly.
-			if ( strtolower( $order->get_transaction_id() === strtolower( $avarda_purchase_id ) ) ) {
+			if ( strtolower( $order->get_transaction_id() ) === strtolower( $avarda_purchase_id ) ) {
 				return true;
 			}
 		}
 		// Return false if we get here. Something went wrong.
 		ACO_Logger::log( 'Avarda general error in process payment handler. Clearing Avarda session and reloading the checkout page. Woo order ID ' . $order_id . '. Avarda purchase ID ' . $avarda_purchase_id );
 		return false;
+	}
+
+	/**
+	 * Handle process payment error.
+	 *
+	 * @param WP_Error|bool $error The error object.
+	 * @param int           $order_id The WooCommerce order ID.
+	 * @param string        $purchase_id The Avarda purchase ID.
+	 *
+	 * @return void
+	 */
+	public function log_process_payment_get_error( $error, $order_id, $purchase_id ) {
+		$message = "Avarda GET request failed in process payment handler. Clearing Avarda session and reloading the checkout page. Woo order ID: $order_id. Avarda purchase ID: $purchase_id";
+		if ( ! is_wp_error( $error ) ) {
+			ACO_Logger::log( $message );
+			return;
+		}
+
+		$code = $error->get_error_code();
+		if ( 'avarda_checkout_payment_invalid' === $code || 'avarda_checkout_session_invalid' === $code ) {
+			$error_message = $error->get_error_message();
+			$message       = "Avarda session failed to validate $error_message. Clearing Avarda session and reloading the checkout page. Woo order ID: $order_id. Avarda purchase ID: $purchase_id";
+		}
+
+		// Unset sessions.
+		ACO_Logger::log( $message );
 	}
 
 
@@ -314,6 +366,8 @@ class ACO_Gateway extends WC_Payment_Gateway {
 			} else {
 				$avarda_change_payment_method_template = apply_filters( 'aco_locate_template', AVARDA_CHECKOUT_PATH . '/templates/avarda-change-payment-method.php', $template_name );
 			}
+
+			ACO_Logger::log( "Loading change payment template for Avarda checkout: {$avarda_change_payment_method_template}", WC_Log_Levels::DEBUG );
 			require $avarda_change_payment_method_template;
 		} else {
 
@@ -322,6 +376,7 @@ class ACO_Gateway extends WC_Payment_Gateway {
 			} else {
 				$avarda_order_receipt_template = apply_filters( 'aco_locate_template', AVARDA_CHECKOUT_PATH . '/templates/avarda-order-receipt.php', $template_name );
 			}
+			ACO_Logger::log( "Loading order receipt template for Avarda checkout: {$avarda_order_receipt_template}", WC_Log_Levels::DEBUG );
 			require $avarda_order_receipt_template;
 
 		}

--- a/classes/class-aco-session.php
+++ b/classes/class-aco-session.php
@@ -12,11 +12,11 @@ defined( 'ABSPATH' ) || exit;
  */
 class ACO_Session {
 	/**
-	 * Avarda order returned from the Avarda API.
+	 * Avarda purchase returned from the Avarda API.
 	 *
 	 * @var array
 	 */
-	protected $avarda_order;
+	protected $avarda_payment;
 
 	/**
 	 * The reference the *Singleton* instance of this class.
@@ -57,33 +57,70 @@ class ACO_Session {
 	}
 
 	/**
-	 * Get the Avarda order. If it's not set, try to set it, and if that fails, return false.
+	 * Get the Avarda payment.
 	 *
-	 * @return array|WP_Error
+	 * If it has not already been set, it will try to get it from the order or the session.
+	 * If no purchase id is found in either the order or session, it will return false.
+	 * If any errors happen during the verification of the payment, it will return a WP_Error object.
+	 *
+	 * @param int|WC_Order $order WooCommerce order. Default is null.
+	 *
+	 * @return array|bool|WP_Error
 	 */
-	public function get_avarda_order() {
-		if ( ! $this->avarda_order ) {
-			$purchase_id = aco_get_purchase_id_from_session();
+	public function get_avarda_payment( $order = null ) {
+		// Maybe get the order if its not a WC_Order object.
+		if ( ! is_a( $order, 'WC_Order' ) ) {
+			$order = wc_get_order( $order );
+		}
 
-			if ( ! $purchase_id ) {
-				return new WP_Error( 'avarda_checkout_missing_purchase_id', __( 'Missing Avarda Checkout purchase id.', 'avarda-checkout-for-woocommerce' ) );
+		// Ensure the current customer session is still valid, but only if we don't have an order.
+		if ( empty( $order ) ) {
+			$verify_session = $this->verify_cart_session();
+
+			if ( is_wp_error( $verify_session ) ) {
+				return $verify_session;
+			}
+		}
+
+		// See if we need to get the avarda payment or not.
+		if ( empty( $this->avarda_payment ) ) {
+			// Get the purchase id from the order or the session.
+			$purchase_id = $order ? $order->get_meta( 'aco_purchase_id' ) : aco_get_purchase_id_from_session();
+
+			// If we did not have any purchase id, it means that we don't have a Avarda payment. So return false to indicate that none exists.
+			if ( empty( $purchase_id ) ) {
+				ACO_Logger::log( 'No purchase id found in order or session when getting Avarda Payment.', WC_Log_Levels::DEBUG );
+				return false;
 			}
 
 			ACO_WC()->api->request_get_payment( $purchase_id );
 		}
 
-		return $this->avarda_order;
+		// If the payment is a WP_Error, return it.
+		if ( is_wp_error( $this->avarda_payment ) ) {
+			return $this->avarda_payment;
+		}
+
+		// Verify the payment.
+		$verify_result = $this->verify_payment( $order );
+
+		// If the payment is invalid, return the error.
+		if ( is_wp_error( $verify_result ) ) {
+			return $verify_result;
+		}
+
+		return $this->avarda_payment;
 	}
 
 	/**
-	 * Set the Avarda order.
+	 * Set the Avarda payment.
 	 *
-	 * @param array $avarda_order Avarda order.
+	 * @param array $avarda_payment Avarda payment.
 	 *
 	 * @return void
 	 */
-	public function set_avarda_order( $avarda_order ) {
-		$this->avarda_order = $avarda_order;
+	public function set_avarda_payment( $avarda_payment ) {
+		$this->avarda_payment = $avarda_payment;
 	}
 
 	/**
@@ -94,10 +131,217 @@ class ACO_Session {
 	 * @return void
 	 */
 	public function update_avarda_order_items( $items ) {
-		if ( ! $this->avarda_order ) {
-			$this->get_avarda_order();
+		if ( ! $this->avarda_payment ) {
+			$this->get_avarda_payment();
 		}
 
-		$this->avarda_order['items'] = $items;
+		$this->avarda_payment['items'] = $items;
+	}
+
+	/**
+	 * Verify the current cart session with stores session.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function verify_cart_session() {
+		try {
+			$this->has_currency_changed()
+				->has_language_changed();
+		} catch ( Exception $e ) {
+			$this->log_verification_exception( $e );
+			return new WP_Error( 'avarda_checkout_session_invalid', $e->getMessage() );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Verify the Avarda payment to ensure its still valid to use.
+	 *
+	 * @param WC_Order|null $order WooCommerce order. Default is null.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function verify_payment( $order = null ) {
+		if ( ! $this->avarda_payment ) {
+			return false;
+		}
+
+		try {
+			// Verify the step first, since it might redirect to the thankyou page.
+			$this->is_payment_step_valid()
+				->has_payment_expired(); // Check if the payment has expired.
+		} catch ( Exception $e ) {
+			$this->log_verification_exception( $e, $order );
+			return new WP_Error( 'avarda_checkout_payment_invalid', $e->getMessage() );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the purchase id for the Avarda session.
+	 *
+	 * @return string
+	 */
+	public function get_purchase_id() {
+		if ( ! $this->avarda_payment ) {
+			return '';
+		}
+
+		return $this->avarda_payment['purchaseId'];
+	}
+
+	/**
+	 * Get the payment step for the Avarda session.
+	 *
+	 * @return string
+	 */
+	public function get_payment_step() {
+		if ( ! $this->avarda_payment ) {
+			return 'unknown';
+		}
+
+		// Lowercase the mode to match the key in the payment object.
+		$mode = lcfirst( $this->avarda_payment['mode'] );
+		$step = $this->avarda_payment[ $mode ]['step']['current'] ?? 'unknown';
+
+		return $step;
+	}
+
+	/**
+	 * Is the step for the payment valid.
+	 *
+	 * @throws Exception If the payment step is invalid.
+	 * @return self
+	 */
+	public function is_payment_step_valid() {
+		if ( ! $this->avarda_payment ) {
+			return $this;
+		}
+
+		$step = $this->get_payment_step();
+
+		switch ( $step ) {
+			case 'TimedOut':
+				throw new Exception( __( 'Avarda Checkout payment has timed out.', 'avarda-checkout-for-woocommerce' ) ); // phpcs:ignore
+			case 'Completed':
+				// Special case, if the payment is completed, then get the WC order and send the customer to the thankyou page for the order.
+				$purchase_id = $this->avarda_payment['purchaseId'];
+				$order       = aco_get_order_by_purchase_id( $purchase_id );
+
+				// If we could not get an order, just return.
+				if ( ! $order ) {
+					return $this;
+				}
+
+				$confirmation_url = add_query_arg(
+					array(
+						'aco_confirm'     => 'yes',
+						'aco_purchase_id' => $purchase_id,
+						'wc_order_id'     => $order->get_id(),
+					),
+					$order->get_checkout_order_received_url()
+				);
+
+				wp_safe_redirect( $confirmation_url );
+				exit;
+			default:
+				return $this; // Default to true to not prevent unknown steps from being valid if Avarda adds new steps.
+		}
+	}
+
+	/**
+	 * Check if the payment has expired or not.
+	 *
+	 * @throws Exception If the payment has expired.
+	 * @return self
+	 */
+	public function has_payment_expired() {
+		if ( ! $this->avarda_payment ) {
+			return $this;
+		}
+
+		$expired_utc = $this->avarda_payment['expiredUtc'] ?? '0';
+		$has_expired = time() > strtotime( $expired_utc );
+
+		if ( $has_expired ) {
+			throw new Exception( __( 'Avarda Checkout payment has expired.', 'avarda-checkout-for-woocommerce' ) ); // phpcs:ignore
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Check if the currency has been changed or not for the customer session.
+	 *
+	 * @throws Exception If the currency has changed.
+	 * @return self
+	 */
+	public function has_currency_changed() {
+		$wc_currency      = get_woocommerce_currency();
+		$session_currency = WC()->session->get( 'aco_currency', '' );
+
+		// If we don't have a session currency, then we don't need to check.
+		if ( empty( $session_currency ) ) {
+			return $this;
+		}
+
+		$has_changed = $wc_currency !== $session_currency;
+		if ( $has_changed ) {
+			throw new Exception( __( 'Avarda Checkout currency has changed.', 'avarda-checkout-for-woocommerce' ) ); // phpcs:ignore
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Check if the language has change or not for the customer session.
+	 *
+	 * @throws Exception If the language has changed.
+	 * @return self
+	 */
+	public function has_language_changed() {
+		$current_language = ACO_WC()->checkout_setup->get_language();
+		$session_language = WC()->session->get( 'aco_language', '' );
+
+		// If we don't have a session language, then we don't need to check.
+		if ( empty( $session_language ) ) {
+			return $this;
+		}
+
+		$has_changed = $current_language !== $session_language;
+
+		if ( $has_changed ) {
+			throw new Exception( __( 'Avarda Checkout language has changed.', 'avarda-checkout-for-woocommerce' ) ); // phpcs:ignore
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Log any verification errors that happen.
+	 *
+	 * @param Exception     $e Exception object.
+	 * @param WC_Order|null $order WooCommerce order.
+	 *
+	 * @return void
+	 */
+	private function log_verification_exception( $e, $order = null ) {
+		$purchase_id = $this->get_purchase_id();
+
+		if ( empty( $purchase_id ) ) {
+			$purchase_id = $order ? $order->get_meta( 'aco_purchase_id' ) : aco_get_purchase_id_from_session();
+		}
+
+		$message = sprintf(
+			/* translators: 1: error message, 2: order id */
+			__( '%1$s Purchase Id: %2$s.%3$s', 'avarda-checkout-for-woocommerce' ),
+			$e->getMessage(),
+			$purchase_id,
+			$order ? '. Order id: ' . $order->get_id() : ''
+		);
+
+		ACO_Logger::log( $message );
 	}
 }

--- a/classes/class-aco-shipping.php
+++ b/classes/class-aco-shipping.php
@@ -96,7 +96,7 @@ class ACO_Shipping extends WC_Shipping_Method {
 	 * @return void
 	 */
 	public function calculate_shipping( $package = array() ) {
-		$avarda_order = ACO_WC()->session()->get_avarda_order();
+		$avarda_order = ACO_WC()->session()->get_avarda_payment();
 
 		// If no Avarda order is set, return.
 		if ( is_wp_error( $avarda_order ) ) {

--- a/classes/class-aco-templates.php
+++ b/classes/class-aco-templates.php
@@ -78,6 +78,7 @@ class ACO_Templates {
 					if ( 'aco' === WC()->session->get( 'chosen_payment_method' ) ) {
 						if ( ! isset( $_GET['confirm'] ) ) {
 							$template = $avarda_checkout_template;
+							ACO_Logger::log( "Loading checkout template for Avarda checkout because ACO is the chosen method: $template", WC_Log_Levels::DEBUG );
 						}
 					}
 
@@ -88,6 +89,7 @@ class ACO_Templates {
 						if ( 'aco' === key( $available_gateways ) ) {
 							if ( ! isset( $_GET['confirm'] ) ) {
 								$template = $avarda_checkout_template;
+								ACO_Logger::log( "Loading checkout template for Avarda checkout because no method is chosen and ACO is the first option: $template", WC_Log_Levels::DEBUG );
 							}
 						}
 					}
@@ -100,6 +102,7 @@ class ACO_Templates {
 							if ( 'aco' === key( $available_gateways ) ) {
 								if ( ! isset( $_GET['confirm'] ) ) {
 									$template = $avarda_checkout_template;
+									ACO_Logger::log( "Loading checkout template for Avarda checkout the chosen method is no longer available, and ACO is the first option: $template", WC_Log_Levels::DEBUG );
 								}
 							}
 						}

--- a/classes/requests/checkout/get/class-aco-request-get-payment.php
+++ b/classes/requests/checkout/get/class-aco-request-get-payment.php
@@ -61,7 +61,7 @@ class ACO_Request_Get_Payment extends ACO_Request {
 		$result = parent::process_response( $response, $request_args, $request_url );
 
 		if ( ! is_wp_error( $result ) ) {
-			ACO_WC()->session()->set_avarda_order( $result );
+			ACO_WC()->session()->set_avarda_payment( $result );
 		}
 
 		return $result;

--- a/classes/requests/checkout/post/class-aco-request-initialize-payment.php
+++ b/classes/requests/checkout/post/class-aco-request-initialize-payment.php
@@ -44,30 +44,27 @@ class ACO_Request_Initialize_Payment extends ACO_Request {
 	 * @return array
 	 */
 	public function get_body( $order_id ) {
-
 		$request_body = array(
-			'checkoutSetup' => ACO_WC()->checkout_setup->get_checkout_setup( $order_id ),
+			'checkoutSetup' => ACO_WC()->checkout_setup->get_checkout_setup( $order_id, $this->international ),
 		);
+
+		$b2b   = false;
+		$order = null;
+
+		// Set order specific data.
 		if ( $order_id ) {
 			$order                 = wc_get_order( $order_id );
 			$request_body['items'] = ACO_WC()->order_items->get_order_items( $order_id );
 			$request_body['extraIdentifiers']['orderReference'] = (string) $order->get_order_number();
-			// Add customer address if it exist.
-			if ( $order->get_billing_company() ) {
-				$customer_address = ACO_WC()->customer->get_b2b_customer( $order_id );
-				if ( ! empty( $customer_address ) ) {
-					$request_body['b2B'] = $customer_address;
-				}
-			} else {
-				$customer_address = ACO_WC()->customer->get_b2c_customer( $order_id );
-				if ( ! empty( $customer_address ) ) {
-					$request_body['b2C'] = $customer_address;
-				}
-			}
-		} else {
+			$b2b = ! empty( $order->get_billing_company() );
+		} else { // Set cart specific data.
 			$request_body['items']            = ACO_WC()->cart_items->get_cart_items();
 			$request_body['shippingSettings'] = ACO_WC()->cart_items->get_shipping_settings();
+			$b2b                              = ! empty( WC()->customer->get_billing_company() );
 		}
+
+		// Add customer details to the request body.
+		$request_body[ $b2b ? 'b2B' : 'b2C' ] = ACO_WC()->customer->get_customer( $order, $b2b );
 
 		return apply_filters( 'aco_create_args', $request_body, $order_id );
 	}

--- a/classes/requests/checkout/put/class-aco-request-update-payment.php
+++ b/classes/requests/checkout/put/class-aco-request-update-payment.php
@@ -25,7 +25,6 @@ class ACO_Request_Update_Payment extends ACO_Request {
 	public function request( $aco_purchase_id, $order_id = null, $force = false ) {
 		$request_url  = $this->base_url . '/api/partner/payments/' . $aco_purchase_id . '/items';
 		$request_args = apply_filters( 'aco_update_payment_args', $this->get_request_args( $order_id ) );
-
 		// Check if we need to update.
 		// @Todo - return false if no update is needed. Before we can do this change we need to change the return data in check_for_api_error() function.
 		if ( WC()->session->get( 'aco_update_md5' ) && WC()->session->get( 'aco_update_md5' ) === md5( wp_json_encode( $request_args ) ) && ! $force ) {
@@ -34,7 +33,6 @@ class ACO_Request_Update_Payment extends ACO_Request {
 
 			return 'No update needed';
 		}
-
 		WC()->session->set( 'aco_update_md5', md5( wp_json_encode( $request_args ) ) );
 
 		$response = wp_remote_request( $request_url, $request_args );

--- a/classes/requests/class-aco-request.php
+++ b/classes/requests/class-aco-request.php
@@ -231,6 +231,11 @@ class ACO_Request {
 			if ( null !== json_decode( $response['body'], true ) ) {
 				$errors = json_decode( $response['body'], true );
 				foreach ( $errors as $error => $aco_error_messages ) {
+					// Ensure the error message is an array so we can loop through it.
+					if ( ! is_array( $aco_error_messages ) ) {
+						$aco_error_messages = array( $aco_error_messages );
+					}
+
 					foreach ( $aco_error_messages as $aco_error_message ) {
 						if ( is_array( $aco_error_message ) ) {
 							foreach ( $aco_error_message as $aco_err_msg ) {

--- a/classes/requests/class-aco-request.php
+++ b/classes/requests/class-aco-request.php
@@ -53,9 +53,23 @@ class ACO_Request {
 	/**
 	 * The request environment.
 	 *
-	 * @var $enviroment
+	 * @var $environment
 	 */
 	public $environment;
+
+	/**
+	 * If the request is authenticated.
+	 *
+	 * @var boolean $auth
+	 */
+	public $auth = false;
+
+	/**
+	 * If the request if using international credentials.
+	 *
+	 * @var boolean $international
+	 */
+	public $international = false;
 
 	/**
 	 * Class constructor
@@ -90,7 +104,7 @@ class ACO_Request {
 	}
 
 	/**
-	 * Sets the enviroment.
+	 * Sets the environment.
 	 *
 	 * @return void
 	 */
@@ -113,31 +127,75 @@ class ACO_Request {
 	 */
 	public function set_environment_variables() {
 		$this->avarda_settings = get_option( 'woocommerce_aco_settings' );
+		$this->testmode        = $this->avarda_settings['testmode'];
 
-		switch ( get_woocommerce_currency() ) {
-			case 'SEK':
-				$this->client_id     = $this->avarda_settings['merchant_id_se'];
-				$this->client_secret = $this->avarda_settings['api_key_se'];
-				break;
-			case 'NOK':
-				$this->client_id     = $this->avarda_settings['merchant_id_no'];
-				$this->client_secret = $this->avarda_settings['api_key_no'];
-				break;
-			case 'DKK':
-				$this->client_id     = $this->avarda_settings['merchant_id_dk'];
-				$this->client_secret = $this->avarda_settings['api_key_dk'];
-				break;
-			case 'EUR':
-				$this->client_id     = $this->avarda_settings['merchant_id_fi'];
-				$this->client_secret = $this->avarda_settings['api_key_fi'];
-				break;
-			default:
-				$this->client_id     = $this->avarda_settings['merchant_id_se'];
-				$this->client_secret = $this->avarda_settings['api_key_se'];
-				break;
-		}
-		$this->testmode = $this->avarda_settings['testmode'];
+		// Get the client id and secret based on the country.
+		$credential_country = $this->get_credential_country();
+		$credentials        = $this->get_credentials( $credential_country );
+
+		// Set the client id and secret and apply filters to allow for customization.
+		$this->client_id     = apply_filters( 'aco_client_id', $credentials['client_id'] ?? '', $this->international );
+		$this->client_secret = apply_filters( 'aco_client_secret', $credentials['client_secret'] ?? '', $this->international );
+
 		$this->base_url = ( 'yes' === $this->testmode ) ? AVARDA_CHECKOUT_TEST_ENV : AVARDA_CHECKOUT_LIVE_ENV;
+	}
+
+	/**
+	 * Get the country to use when getting the credentials from the settings.
+	 *
+	 * @param WC_Order|int|null $order The WooCommerce order, order id or null if we are using the cart.
+	 *
+	 * @return string The country code.
+	 */
+	public function get_credential_country( $order = null ) {
+		if ( ! $order instanceof WC_Order ) {
+			$order = wc_get_order( $order );
+		}
+
+		$currency         = $order ? $order->get_currency() : get_woocommerce_currency();
+		$currency_country = array(
+			'SEK' => 'se',
+			'NOK' => 'no',
+			'DKK' => 'dk',
+			'EUR' => 'fi',
+		);
+
+		return $currency_country[ $currency ] ?? ''; // Default to se if the currency is not a supported currency.
+	}
+
+	/**
+	 * Get the credentials to use for the country.
+	 *
+	 * @param string $country The country code.
+	 *
+	 * @return array The credentials.
+	 */
+	public function get_credentials( $country ) {
+		$client_id     = '';
+		$client_secret = '';
+
+		if ( isset( $this->avarda_settings[ 'merchant_id_' . $country ] ) && isset( $this->avarda_settings[ 'api_key_' . $country ] ) ) {
+			$client_id     = $this->avarda_settings[ 'merchant_id_' . $country ];
+			$client_secret = $this->avarda_settings[ 'api_key_' . $country ];
+		}
+
+		// If the client id or secret is still empty, use the international credentials.
+		if ( empty( $client_id ) || empty( $client_secret ) ) {
+			$client_id           = $this->avarda_settings['merchant_id_int'] ?? null;
+			$client_secret       = $this->avarda_settings['api_key_int'] ?? null;
+			$this->international = true;
+		}
+
+		return apply_filters(
+			'aco_credentials',
+			array(
+				'client_id'     => $client_id,
+				'client_secret' => $client_secret,
+			),
+			$country,
+			$this->international,
+			$this->testmode
+		);
 	}
 
 	/**

--- a/classes/requests/helpers/class-aco-helper-cart.php
+++ b/classes/requests/helpers/class-aco-helper-cart.php
@@ -134,12 +134,16 @@ class ACO_Helper_Cart {
 		$height = empty( $height ) ? 0 : $height;
 
 		$shipping_params = array(
-			'weight'     => wc_get_weight( $weight, 'g' ),
-			'length'     => wc_get_dimension( $length, 'mm' ),
-			'width'      => wc_get_dimension( $width, 'mm' ),
-			'height'     => wc_get_dimension( $height, 'mm' ),
-			'attributes' => array( $shipping_class ),
+			'weight' => wc_get_weight( $weight, 'g' ),
+			'length' => wc_get_dimension( $length, 'mm' ),
+			'width'  => wc_get_dimension( $width, 'mm' ),
+			'height' => wc_get_dimension( $height, 'mm' ),
 		);
+
+		// Only set the attributes if the shipping class is not empty.
+		if ( ! empty( $shipping_class ) ) {
+			$shipping_params['attributes'] = array( $shipping_class );
+		}
 
 		$shipping_params = apply_filters( 'aco_item_shipping_params', $shipping_params, $product );
 

--- a/classes/requests/helpers/class-aco-helper-checkout-setup.php
+++ b/classes/requests/helpers/class-aco-helper-checkout-setup.php
@@ -16,10 +16,12 @@ class ACO_Helper_Checkout_Setup {
 	/**
 	 * Gets checkout setup.
 	 *
-	 * @param int $order_id The WooCommerce order id.
+	 * @param int  $order_id The WooCommerce order id.
+	 * @param bool $is_international Whether the order is international or not.
+	 *
 	 * @return array Formatted checkout setup.
 	 */
-	public function get_checkout_setup( $order_id = null ) {
+	public function get_checkout_setup( $order_id = null, $is_international = false ) {
 
 		$avarda_settings = get_option( 'woocommerce_aco_settings' );
 		$age_validation  = $avarda_settings['age_validation'] ?? '';
@@ -52,6 +54,11 @@ class ACO_Helper_Checkout_Setup {
 		// Age validation.
 		if ( ! empty( $age_validation ) ) {
 			$checkout_setup['ageValidation'] = $age_validation;
+		}
+
+		// Set the international properties to the checkout setup if the order is international.
+		if ( $is_international ) {
+			$checkout_setup = $this->set_international_properties( $checkout_setup );
 		}
 
 		return $checkout_setup;
@@ -99,4 +106,18 @@ class ACO_Helper_Checkout_Setup {
 		return apply_filters( 'aco_wc_terms_url', $terms_url );
 	}
 
+	/**
+	 * Set international properties.
+	 *
+	 * @param array $checkout_setup The checkout setup.
+	 *
+	 * @return array
+	 */
+	private function set_international_properties( $checkout_setup ) {
+		$checkout_setup['enableCountrySelector'] = true;
+		$checkout_setup['invoicingCountries']    = array_keys( WC()->countries->get_allowed_countries() );
+		$checkout_setup['deliveryCountries']     = array_keys( WC()->countries->get_shipping_countries() );
+
+		return $checkout_setup;
+	}
 }

--- a/includes/aco-form-fields.php
+++ b/includes/aco-form-fields.php
@@ -164,5 +164,22 @@ $settings = array(
 		'default'  => '',
 		'desc_tip' => true,
 	),
+	// International.
+	'credentials_international'  => array(
+		'title' => 'API Credentials International',
+		'type'  => 'title',
+	),
+	'merchant_id_int'            => array(
+		'title'    => __( 'Client ID', 'avarda-checkout-for-woocommerce' ),
+		'type'     => 'text',
+		'default'  => '',
+		'desc_tip' => true,
+	),
+	'api_key_int'                => array(
+		'title'    => __( 'Client Secret', 'avarda-checkout-for-woocommerce' ),
+		'type'     => 'text',
+		'default'  => '',
+		'desc_tip' => true,
+	),
 );
 return apply_filters( 'aco_settings', $settings );


### PR DESCRIPTION
Should be merged after [PR #80](https://github.com/krokedil/avarda-checkout-for-woocommerce/pull/80)

* Enhancement - Improved session handling with Avarda to reduce the amount of requests needed for each order.
* Enhancement - Added log levels to different log messages to allow limiting of the messages logged.
* Fix - Fixes an issue with token validation when loading the Javascript that caused us to not properly handle orders that had been completed, and had their session expired in Avarda.
* Fix - Fixed several PHP 8.2 deprecation errors.