### PR TITLE
Allow float value for taxCode

### DIFF
--- a/classes/requests/helpers/class-aco-helper-cart.php
+++ b/classes/requests/helpers/class-aco-helper-cart.php
@@ -222,10 +222,13 @@ class ACO_Helper_Cart {
 	 * Gets the tax code for the product.
 	 *
 	 * @param object $cart_item The cart item.
-	 * @return float
+	 * @return string
 	 */
 	public function get_product_tax_code( $cart_item ) {
-		return (string) round( $this->get_product_tax_rate( $cart_item ) * 100 );
+		if ( 0 === intval( $cart_item['line_total'] ) ) {
+			return '0';
+		}
+		return (string) number_format( ( $cart_item['line_tax'] / $cart_item['line_total'] ) * 100, 1, '.', '' );
 	}
 
 	/**

--- a/classes/requests/helpers/class-aco-helper-cart.php
+++ b/classes/requests/helpers/class-aco-helper-cart.php
@@ -225,10 +225,10 @@ class ACO_Helper_Cart {
 	 * @return string
 	 */
 	public function get_product_tax_code( $cart_item ) {
-		if ( 0 === intval( $cart_item['line_total'] ) ) {
-			return '0';
-		}
-		return (string) number_format( ( $cart_item['line_tax'] / $cart_item['line_total'] ) * 100, 1, '.', '' );
+		$tax_class = isset( $cart_item['data'] ) ? $cart_item['data']->get_tax_class() : false;
+		$tax_rate  = $tax_class && WC_Tax::get_rates( $tax_class ) ? reset( WC_Tax::get_rates( $tax_class ) )['rate'] : 0;
+
+		return (string) $tax_rate;
 	}
 
 	/**

--- a/classes/requests/helpers/class-aco-helper-cart.php
+++ b/classes/requests/helpers/class-aco-helper-cart.php
@@ -225,10 +225,21 @@ class ACO_Helper_Cart {
 	 * @return string
 	 */
 	public function get_product_tax_code( $cart_item ) {
-		$tax_class = isset( $cart_item['data'] ) ? $cart_item['data']->get_tax_class() : false;
-		$tax_rate  = $tax_class && WC_Tax::get_rates( $tax_class ) ? reset( WC_Tax::get_rates( $tax_class ) )['rate'] : 0;
+		// Check if 'data' exists and get the tax class, and ensure get_tax_class exists as a method to prevent errors.
+		if ( isset( $cart_item['data'] ) && method_exists( $cart_item['data'], 'get_tax_class' ) ) {
+			$tax_class = $cart_item['data']->get_tax_class();
 
-		return (string) $tax_rate;
+			// Get the tax rates from the tax class.
+			$rates = WC_Tax::get_rates( $tax_class );
+			if ( ! empty( $rates ) ) {
+				$first_rate = reset( $rates ); // Only use the first rate returned.
+				// Check if 'rate' key exists; otherwise, fallback to 0
+				return (string) ( $first_rate['rate'] ?? 0 );
+			}
+		}
+
+		// Return a default value if no rate is found.
+		return '0';
 	}
 
 	/**

--- a/classes/requests/helpers/class-aco-helper-order.php
+++ b/classes/requests/helpers/class-aco-helper-order.php
@@ -139,7 +139,7 @@ class ACO_Helper_Order {
 		foreach ( $tax_items as $tax_item ) {
 			$rate_id = $tax_item->get_rate_id();
 			if ( key( $order_item->get_taxes()['total'] ) === $rate_id ) {
-				return (string) number_format( WC_Tax::_get_tax_rate( $rate_id )['tax_rate'] * 100, 1, '.', '' );
+				return (string) WC_Tax::_get_tax_rate( $rate_id )['tax_rate'];
 			}
 		}
 	}

--- a/classes/requests/helpers/class-aco-helper-order.php
+++ b/classes/requests/helpers/class-aco-helper-order.php
@@ -132,14 +132,14 @@ class ACO_Helper_Order {
 	 *
 	 * @param object $order The order item.
 	 * @param object $order_item The WooCommerce order item.
-	 * @return float
+	 * @return string
 	 */
 	public function get_product_tax_code( $order, $order_item ) {
 		$tax_items = $order->get_items( 'tax' );
 		foreach ( $tax_items as $tax_item ) {
 			$rate_id = $tax_item->get_rate_id();
 			if ( key( $order_item->get_taxes()['total'] ) === $rate_id ) {
-				return (string) round( WC_Tax::_get_tax_rate( $rate_id )['tax_rate'], 2 );
+				return (string) number_format( WC_Tax::_get_tax_rate( $rate_id )['tax_rate'] * 100, 1, '.', '' );
 			}
 		}
 	}


### PR DESCRIPTION
Not sure if this is what we want and covers all scenarios, but this generates: `[taxCode] => 25.5` For a 25.5% tax, `[taxCode] => 12.0` For a 12% tax.