### PR TITLE
Develop shipping widget updates

### DIFF
--- a/assets/js/aco_shipping_widget.js
+++ b/assets/js/aco_shipping_widget.js
@@ -599,10 +599,16 @@ jQuery(function($) {
          * @returns {string}
          */
         formatPrice: (price) => {
-            const priceFormat = aco_wc_shipping_params.price_format;
-            const format = priceFormat.format;
-            const symbol = priceFormat.symbol;
-            return format.replace("%2$s", price).replace("%1$s", symbol);
+            const { format, symbol, trim_zero_decimals } = aco_wc_shipping_params.price_format;
+
+            // If the price ends with .00, .0, ,00 or ,0, trim it.
+            if (trim_zero_decimals) {
+                price = price.replace(/(\.00|\.0|,00|,0)$/, "");
+            }
+
+            price = format.replace("%2$s", price).replace("%1$s", symbol);
+
+            return price;
         },
 
         /**

--- a/assets/js/aco_shipping_widget.js
+++ b/assets/js/aco_shipping_widget.js
@@ -35,7 +35,7 @@ jQuery(function($) {
             const optionsHtml = aco_shipping_widget.getOptionsHtml();
 
             // Append the options HTML to the element.
-            $element.append(optionsHtml);
+            $element.html(optionsHtml);
 
             // Register the change event for the radio buttons.
             $element.on( "change", 'input:radio[name="aco_shipping_method"]:checked', function () {

--- a/assets/js/aco_shipping_widget.js
+++ b/assets/js/aco_shipping_widget.js
@@ -23,6 +23,12 @@ jQuery(function($) {
 
         init: (initObject) => {
             const { element, session_id, config } = initObject;
+            // If the config is null, return.
+            if (!config || !config.modules) {
+                console.error("Avarda Checkout Shipping Widget: No config found or modules found.");
+                return;
+            }
+
             const $element = $(element);
             aco_shipping_widget.element = $element;
             aco_shipping_widget.cartNeedsShipping = aco_wc_shipping_params.cart_needs_shipping;

--- a/classes/api/models/shipping/class-aco-shipping-option-model.php
+++ b/classes/api/models/shipping/class-aco-shipping-option-model.php
@@ -91,7 +91,7 @@ class ACO_Shipping_Option_Model {
 		$option->carrier         = self::get_shipping_method_carrier( $shipping_rate );
 		$option->iconUrl         = self::get_shipping_method_icon( $option->carrier, $shipping_rate );
 		$option->shippingProduct = $shipping_rate->get_label();
-		$option->price           = floatval( $shipping_rate->get_cost() ) + array_sum( $shipping_rate->get_taxes() );
+		$option->price           = number_format( $shipping_rate->get_cost() + array_sum( $shipping_rate->get_taxes() ), 2, '.', '' );
 		$option->currency        = get_woocommerce_currency();
 		$option->description     = self::get_shipping_method_description( $shipping_rate );
 

--- a/classes/api/models/shipping/class-aco-shipping-session-model.php
+++ b/classes/api/models/shipping/class-aco-shipping-session-model.php
@@ -45,7 +45,8 @@ class ACO_Shipping_Session_Model extends ACO_Shipping_Response_Model {
 	 */
 	public static function from_shipping_rates( $shipping_rates, $chosen_shipping_method, $purchase_id ) {
 		$session            = new self();
-		$selected           = $shipping_rates[ $chosen_shipping_method ] ?? $shipping_rates[ array_key_first( $shipping_rates ) ] ?? null;
+        $default_rate       = is_array( $shipping_rates ) && ! empty( $shipping_rates ) ? array_key_first( $shipping_rates ) : null;
+		$selected           = $shipping_rates[ $chosen_shipping_method ] ?? $default_rate;
 		$session->id        = $purchase_id;
 		$session->expiresAt = gmdate( 'Y-m-d\TH:i:s\Z', time() + 60 * 60 ); // 1 hour from now same as Avarda.
 		$session->status    = 'ACTIVE';

--- a/classes/class-aco-assets.php
+++ b/classes/class-aco-assets.php
@@ -212,6 +212,7 @@ class ACO_Assets {
 			'cart_needs_shipping'             => WC()->cart->needs_shipping(),
 			'spinner_text'                    => apply_filters( 'aco_shipping_widget_spinner_text', __( 'Waiting for shipping options...', 'avarda-checkout-for-woocommerce' ) ),
 			'price_format'                    => array(
+				'trim_zero_decimals' => apply_filters( 'woocommerce_price_trim_zeros', false ),
 				'format' => get_woocommerce_price_format(),
 				'symbol' => get_woocommerce_currency_symbol(),
 			),


### PR DESCRIPTION
* Enhancement - Made the filter `woocommerce_price_trim_zeros` apply to the display of shipping prices as well, so prices ending in zero decimals will be trimmed if the filter returns a true value.
* Fix - Fixed an issue possibly showing the shipping widget twice before the customer filled in their address.
* Fix - Fixed an issue that could happen if no modules where sent to the shipping widget.
* Fix - Fixed a possible issue with rounding decimals for the shipping options in the shipping widget.
* Fix - Fixed a potential error that could happen when Avarda made a request to get the shipping session, if no shipping methods where calculated.