### PR TITLE
Fix load text domain notice

### DIFF
--- a/classes/class-aco-order-management.php
+++ b/classes/class-aco-order-management.php
@@ -33,12 +33,21 @@ class ACO_Order_Management {
 		// add_action( 'woocommerce_saved_order_items', array( $this, 'update_order' ), 10, 2 ); // for aco refund .
 
 		// Add the shipping metabox to the edit order page.
+		add_action( 'init', array( $this, 'add_shipping_metabox' ) );
+
+		add_filter( 'woocommerce_hidden_order_itemmeta', array( $this, 'add_hidden_order_itemmeta' ) );
+	}
+
+	/**
+	 * Add the shipping metabox to the edit order page.
+	 *
+	 * @return void
+	 */
+	public function add_shipping_metabox() {
 		$shipping_edit_order_page = new EditOrderPage( ACO_WC()->pickup_points );
 		$shipping_edit_order_page
 			->set_metabox_title( __( 'Avarda Shipping Information', 'avarda-checkout-for-woocommerce' ) )
 			->set_can_change_pickup_point( false );
-
-		add_filter( 'woocommerce_hidden_order_itemmeta', array( $this, 'add_hidden_order_itemmeta' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes "Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the avarda-checkout-for-woocommerce domain was triggered too early." while still loading metabox.