### PR TITLE
Prevent init from running twice

### DIFF
--- a/assets/js/aco_shipping_widget.js
+++ b/assets/js/aco_shipping_widget.js
@@ -8,7 +8,6 @@ jQuery(function($) {
         hasFullAddress: false,
         changedShippingOption: false,
         cartNeedsShipping: false,
-        initialized: false,
 
         registerEvents: () => {
             // Set the payment method to aco if we have the payment method radio buttons.
@@ -30,11 +29,6 @@ jQuery(function($) {
                 console.error("Avarda Checkout Shipping Widget: No config found or modules found.");
                 return;
             }
-
-            if (aco_shipping_widget.initialized) {
-                return;
-            }
-            aco_shipping_widget.initialized = true;
 
             const $element = $(element);
             aco_shipping_widget.element = $element;
@@ -69,6 +63,9 @@ jQuery(function($) {
                 aco_shipping_widget.modules.selected_option = shippingMethod;
             });
 
+            // Deregister previous click events to avoid multiple bindings.
+            $element.off( 'click', '.pickup-point-select-header', aco_shipping_widget.onPickupPointSelectClick );
+            $element.off( 'click', '.pickup-point-select-item', aco_shipping_widget.onChangePickupPoint );
             // Register the click event for the pickup point select box.
             $element.on( 'click', '.pickup-point-select-header', aco_shipping_widget.onPickupPointSelectClick );
             $element.on( 'click', '.pickup-point-select-item', aco_shipping_widget.onChangePickupPoint );

--- a/assets/js/aco_shipping_widget.js
+++ b/assets/js/aco_shipping_widget.js
@@ -8,6 +8,7 @@ jQuery(function($) {
         hasFullAddress: false,
         changedShippingOption: false,
         cartNeedsShipping: false,
+        initialized: false,
 
         registerEvents: () => {
             // Set the payment method to aco if we have the payment method radio buttons.
@@ -29,6 +30,11 @@ jQuery(function($) {
                 console.error("Avarda Checkout Shipping Widget: No config found or modules found.");
                 return;
             }
+
+            if (aco_shipping_widget.initialized) {
+                return;
+            }
+            aco_shipping_widget.initialized = true;
 
             const $element = $(element);
             aco_shipping_widget.element = $element;

--- a/assets/js/aco_shipping_widget.js
+++ b/assets/js/aco_shipping_widget.js
@@ -31,6 +31,9 @@ jQuery(function($) {
             }
 
             const $element = $(element);
+            // Remove previous event handlers with the namespace to avoid duplicates.
+            $element.off(".aco_shipping_ui");
+
             aco_shipping_widget.element = $element;
             aco_shipping_widget.cartNeedsShipping = aco_wc_shipping_params.cart_needs_shipping;
 
@@ -45,7 +48,7 @@ jQuery(function($) {
             $element.html(optionsHtml);
 
             // Register the change event for the radio buttons.
-            $element.on( "change", 'input:radio[name="aco_shipping_method"]:checked', function () {
+            $element.on("change.aco_shipping_ui", 'input:radio[name="aco_shipping_method"]:checked', function () {
                 aco_shipping_widget.blockElement("body");
                 const shippingMethod = $(this).val();
 
@@ -63,14 +66,10 @@ jQuery(function($) {
                 aco_shipping_widget.modules.selected_option = shippingMethod;
             });
 
-            // Deregister previous click events to avoid multiple bindings.
-            $element.off( 'click', '.pickup-point-select-header', aco_shipping_widget.onPickupPointSelectClick );
-            $element.off( 'click', '.pickup-point-select-item', aco_shipping_widget.onChangePickupPoint );
-            // Register the click event for the pickup point select box.
-            $element.on( 'click', '.pickup-point-select-header', aco_shipping_widget.onPickupPointSelectClick );
-            $element.on( 'click', '.pickup-point-select-item', aco_shipping_widget.onChangePickupPoint );
+            $element.on('click.aco_shipping_ui', '.pickup-point-select-header', aco_shipping_widget.onPickupPointSelectClick);
+            $element.on('click.aco_shipping_ui', '.pickup-point-select-item', aco_shipping_widget.onChangePickupPoint);
 
-            $(document.body).on('updated_checkout', () => {
+            $(document.body).on('updated_checkout.aco_shipping_ui', () => {
                 if(aco_shipping_widget.changedShippingOption) {
                     aco_shipping_widget.dispatchEvent("shipping_option_changed");
                     aco_shipping_widget.changedShippingOption = false;


### PR DESCRIPTION
Prevent init from running twice, which seemingly happens in some instances (always resolved on reload).

Fixes the merchant reported issue of double click events being triggered on pickup point select, which creates instant closing of the select after attempt to open.

Could this be prevented in a different way? The script is not included twice on the page.