### PR TITLE
Add control for more subscription types

### DIFF
--- a/classes/class-aco-gateway.php
+++ b/classes/class-aco-gateway.php
@@ -151,7 +151,7 @@ class ACO_Gateway extends WC_Payment_Gateway {
 		}
 
 		// Avarda doesn't support 0 value subscriptions.
-		if ( class_exists( 'WC_Subscriptions_Cart' ) && ( WC_Subscriptions_Cart::cart_contains_subscription() || wcs_cart_contains_renewal() ) ) {
+		if ( aco_get_wc_cart_contains_subscription() ) {
 			if ( 0 == round( WC()->cart->total, 2 ) ) { // phpcs:ignore
 				ACO_Logger::log( 'Subscription total is 0. The Avarda Checkout payment gateway is not available.', WC_Log_Levels::DEBUG );
 				return false;

--- a/includes/aco-functions.php
+++ b/includes/aco-functions.php
@@ -773,14 +773,17 @@ function aco_payment_steps_approved_for_update_request() {
 /**
  * Returns if WooCommerce cart contains subscription product or not.
  *
- * @return string The payment state.
+ * @hook aco_wc_cart_contains_subscription
+ * @return bool TRUE if cart contains subscription, otherwise FALSE.
  */
 function aco_get_wc_cart_contains_subscription() {
-	$contains_subscription = false;
+	$contains_subscription = ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) ||
+		( function_exists( 'wcs_cart_contains_renewal' ) && wcs_cart_contains_renewal() ) ||
+		( function_exists( 'wcs_cart_contains_failed_renewal_order_payment' ) && wcs_cart_contains_failed_renewal_order_payment() ) ||
+		( function_exists( 'wcs_cart_contains_resubscribe' ) && wcs_cart_contains_resubscribe() ) ||
+		( function_exists( 'wcs_cart_contains_early_renewal' ) && wcs_cart_contains_early_renewal() ) ||
+		( function_exists( 'wcs_cart_contains_switches' ) && wcs_cart_contains_switches() );
 
-	if ( ( class_exists( 'WC_Subscriptions_Cart' ) && ( WC_Subscriptions_Cart::cart_contains_subscription() || wcs_cart_contains_renewal() ) ) ) {
-		$contains_subscription = true;
-	}
 	return apply_filters( 'aco_wc_cart_contains_subscription', $contains_subscription );
 }
 


### PR DESCRIPTION
The current check for whether a cart contains a subscription doesn't cover all subscription types. This PR should cover all of them.

https://app.clickup.com/t/869b2wz9y