### PR TITLE
Set taxes to 0 for nshift shipping

### DIFF
--- a/classes/class-aco-shipping.php
+++ b/classes/class-aco-shipping.php
@@ -257,7 +257,7 @@ class ACO_Shipping extends WC_Shipping_Method {
 		$price_ex_vat          = $price_inc_vat - $vat_amount;
 
 		// Get the shipping price without VAT.
-		$shipping_tax = WC_Tax::calc_shipping_tax( $price_ex_vat, WC_Tax::get_shipping_tax_rates() );
+		$shipping_tax = array( 0 );
 
 		$rate = array(
 			'id'          => $this->get_rate_id(),


### PR DESCRIPTION
Set taxes to 0 when processing nshift shipping, to resolve issue with nshift mismatches in shipping tax.

Not sure if this is the correct solution but does resolve the "The order could not be verified, please try again." error that can occur when we validate the totals when using nshift shipping.