### PR TITLE
Fixed rounding error

### DIFF
--- a/avarda-checkout-for-woocommerce.php
+++ b/avarda-checkout-for-woocommerce.php
@@ -373,6 +373,7 @@ if ( ! class_exists( 'Avarda_Checkout_For_WooCommerce' ) ) {
 			include_once AVARDA_CHECKOUT_PATH . '/classes/api/class-aco-api-registry.php';
 
 			// Request Helpers.
+			include_once AVARDA_CHECKOUT_PATH . '/classes/requests/helpers/class-aco-helper-item-amount.php';
 			include_once AVARDA_CHECKOUT_PATH . '/classes/requests/helpers/class-aco-helper-cart.php';
 			include_once AVARDA_CHECKOUT_PATH . '/classes/requests/helpers/class-aco-helper-order.php';
 			include_once AVARDA_CHECKOUT_PATH . '/classes/requests/helpers/class-aco-helper-create-refund-data.php';

--- a/classes/requests/helpers/class-aco-helper-cart.php
+++ b/classes/requests/helpers/class-aco-helper-cart.php
@@ -64,13 +64,22 @@ class ACO_Helper_Cart {
 
 			$retrieved_giftcards = $giftcards->get_cart_giftcards();
 			foreach ( $retrieved_giftcards as $retrieved_giftcard ) {
+				// get_total_amount() and get_total_tax_amount() are line totals, so they have to be
+				// converted to per item amounts before they can be paired with a quantity.
+				$giftcard_item = ACO_Helper_Item_Amount::get_item(
+					$retrieved_giftcard->get_name(),
+					$retrieved_giftcard->get_total_amount(),
+					$retrieved_giftcard->get_total_tax_amount(),
+					$retrieved_giftcard->get_quantity()
+				);
+
 				$formatted_cart_items[] = array(
 					'note'        => $retrieved_giftcard->get_sku(),
-					'description' => $retrieved_giftcard->get_name(),
-					'quantity'    => $retrieved_giftcard->get_quantity(),
-					'amount'      => $retrieved_giftcard->get_total_amount(),
+					'description' => $giftcard_item['description'],
+					'quantity'    => $giftcard_item['quantity'],
+					'amount'      => $giftcard_item['amount'],
 					'taxCode'     => $retrieved_giftcard->get_tax_rate(),
-					'taxAmount'   => $retrieved_giftcard->get_total_tax_amount(),
+					'taxAmount'   => $giftcard_item['taxAmount'],
 				);
 			}
 		}
@@ -90,13 +99,20 @@ class ACO_Helper_Cart {
 		} else {
 			$product = wc_get_product( $cart_item['product_id'] );
 		}
+		$item = ACO_Helper_Item_Amount::get_item(
+			$this->get_product_name( $cart_item ),
+			$cart_item['line_total'] + $cart_item['line_tax'],
+			$cart_item['line_tax'],
+			$cart_item['quantity']
+		);
+
 		return array(
-			'description'        => substr( $this->get_product_name( $cart_item ), 0, 34 ), // String.
+			'description'        => $item['description'], // String.
 			'notes'              => substr( $this->get_product_sku( $product ), 0, 34 ), // String.
-			'amount'             => $this->get_product_price( $cart_item ), // Float.
+			'amount'             => $item['amount'], // Float.
 			'taxCode'            => $this->get_product_tax_code( $cart_item ), // String.
-			'taxAmount'          => number_format( $cart_item['line_tax'] / $cart_item['quantity'], 2, '.', '' ), // Float.
-			'quantity'           => $cart_item['quantity'],
+			'taxAmount'          => $item['taxAmount'], // Float.
+			'quantity'           => $item['quantity'],
 			'shippingParameters' => $this->get_product_shipping_params( $product ),
 		);
 	}

--- a/classes/requests/helpers/class-aco-helper-cart.php
+++ b/classes/requests/helpers/class-aco-helper-cart.php
@@ -211,17 +211,6 @@ class ACO_Helper_Cart {
 	}
 
 	/**
-	 * Gets the products price.
-	 *
-	 * @param object $cart_item The cart item.
-	 * @return float
-	 */
-	public function get_product_price( $cart_item ) {
-		$items_subtotal = ( $cart_item['line_total'] + $cart_item['line_tax'] ) / $cart_item['quantity'];
-		return number_format( $items_subtotal, 2, '.', '' );
-	}
-
-	/**
 	 * Gets the tax rate for the product.
 	 *
 	 * @param object $cart_item The cart item.

--- a/classes/requests/helpers/class-aco-helper-item-amount.php
+++ b/classes/requests/helpers/class-aco-helper-item-amount.php
@@ -22,7 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * When the per item amounts round trip exactly we keep them together with the quantity. When they
  * do not, the line is sent as a single item carrying the exact line total, which is the same
- * representation the refund endpoint already uses.
+ * representation the refund endpoint already uses. Lines with a fractional quantity always take
+ * that route, since the quantity field cannot express one.
  */
 class ACO_Helper_Item_Amount {
 
@@ -36,18 +37,22 @@ class ACO_Helper_Item_Amount {
 	 * @return array
 	 */
 	public static function get_item( $description, $total_incl_tax, $total_tax, $quantity ) {
-		$quantity    = max( 1, intval( $quantity ) );
-		$total_minor = self::to_minor_units( $total_incl_tax );
-		$tax_minor   = self::to_minor_units( $total_tax );
+		$raw_quantity = floatval( $quantity );
+		$is_whole     = floor( $raw_quantity ) === $raw_quantity;
+		$quantity     = max( 1, intval( $quantity ) );
+		$total_minor  = self::to_minor_units( $total_incl_tax );
+		$tax_minor    = self::to_minor_units( $total_tax );
 
-		if ( $quantity > 1 ) {
+		// A fractional quantity cannot be carried by the quantity field, so such a line has to be
+		// collapsed even when the per item amounts would divide evenly.
+		if ( $quantity > 1 && $is_whole ) {
 			$unit_minor     = intval( round( $total_minor / $quantity ) );
 			$unit_tax_minor = intval( round( $tax_minor / $quantity ) );
 
 			// Only keep the quantity if Avarda can reproduce both line totals from the per item amounts.
 			if ( $unit_minor * $quantity === $total_minor && $unit_tax_minor * $quantity === $tax_minor ) {
 				return array(
-					'description' => substr( $description, 0, 34 ),
+					'description' => self::truncate_description( $description ),
 					'amount'      => self::from_minor_units( $unit_minor ),
 					'taxAmount'   => self::from_minor_units( $unit_tax_minor ),
 					'quantity'    => $quantity,
@@ -57,10 +62,12 @@ class ACO_Helper_Item_Amount {
 
 		// The per item amounts would lose money, so send the line as a single exact item. Keep the
 		// quantity visible in the description, since it is no longer carried by the quantity field.
-		$description = $quantity > 1 ? $quantity . ' x ' . $description : $description;
+		if ( $raw_quantity > 1 ) {
+			$description = (string) $raw_quantity . ' x ' . $description;
+		}
 
 		return array(
-			'description' => substr( $description, 0, 34 ),
+			'description' => self::truncate_description( $description ),
 			'amount'      => self::from_minor_units( $total_minor ),
 			'taxAmount'   => self::from_minor_units( $tax_minor ),
 			'quantity'    => 1,

--- a/classes/requests/helpers/class-aco-helper-item-amount.php
+++ b/classes/requests/helpers/class-aco-helper-item-amount.php
@@ -68,6 +68,20 @@ class ACO_Helper_Item_Amount {
 	}
 
 	/**
+	 * Truncates a description to the length Avarda accepts for the field, which their API
+	 * reference documents as 35 characters.
+	 *
+	 * Counting characters rather than bytes keeps a multibyte character from being cut in half,
+	 * which would otherwise produce invalid UTF-8 in the request body.
+	 *
+	 * @param string $description The untruncated description.
+	 * @return string
+	 */
+	private static function truncate_description( $description ) {
+		return rtrim( mb_substr( (string) $description, 0, 34 ) );
+	}
+
+	/**
 	 * Converts a price to minor units.
 	 *
 	 * @param float $amount The price in major units.

--- a/classes/requests/helpers/class-aco-helper-item-amount.php
+++ b/classes/requests/helpers/class-aco-helper-item-amount.php
@@ -30,10 +30,11 @@ class ACO_Helper_Item_Amount {
 	/**
 	 * Builds the description, amount, taxAmount and quantity for an order line.
 	 *
-	 * @param string $description The untruncated item description.
-	 * @param float  $total_incl_tax The line total including tax.
-	 * @param float  $total_tax The line tax total.
-	 * @param int    $quantity The line quantity.
+	 * @param string    $description The untruncated item description.
+	 * @param float     $total_incl_tax The line total including tax.
+	 * @param float     $total_tax The line tax total.
+	 * @param float|int $quantity The line quantity. Fractional quantities are supported, but cannot
+	 *                  be carried by Avarda's quantity field, so such lines are always collapsed.
 	 * @return array
 	 */
 	public static function get_item( $description, $total_incl_tax, $total_tax, $quantity ) {

--- a/classes/requests/helpers/class-aco-helper-item-amount.php
+++ b/classes/requests/helpers/class-aco-helper-item-amount.php
@@ -1,0 +1,89 @@
+<?php // phpcs:ignore
+/**
+ * Item amount helper class.
+ *
+ * @package Avarda_Checkout/Classes/Requests/Helpers
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Converts WooCommerce line totals into an item representation that Avarda can reproduce exactly.
+ *
+ * Avarda derives the order total from amount * quantity, where amount is the price of a single
+ * item including tax. @see https://docs.avarda.com/checkout-3/api-reference/checkout-3-api-types/
+ *
+ * WooCommerce rounds tax at line level, so a line total divided by its quantity is not always
+ * representable in two decimals. A line of 5 x 4.31 at 24% VAT totals 26.72 including tax, which
+ * gives 5.344 per item - and neither 5.34 nor 5.35 multiplied by 5 returns 26.72. The per item
+ * value is not even stable, since WooCommerce re-rounds the line tax for every quantity.
+ *
+ * When the per item amounts round trip exactly we keep them together with the quantity. When they
+ * do not, the line is sent as a single item carrying the exact line total, which is the same
+ * representation the refund endpoint already uses.
+ */
+class ACO_Helper_Item_Amount {
+
+	/**
+	 * Builds the description, amount, taxAmount and quantity for an order line.
+	 *
+	 * @param string $description The untruncated item description.
+	 * @param float  $total_incl_tax The line total including tax.
+	 * @param float  $total_tax The line tax total.
+	 * @param int    $quantity The line quantity.
+	 * @return array
+	 */
+	public static function get_item( $description, $total_incl_tax, $total_tax, $quantity ) {
+		$quantity    = max( 1, intval( $quantity ) );
+		$total_minor = self::to_minor_units( $total_incl_tax );
+		$tax_minor   = self::to_minor_units( $total_tax );
+
+		if ( $quantity > 1 ) {
+			$unit_minor     = intval( round( $total_minor / $quantity ) );
+			$unit_tax_minor = intval( round( $tax_minor / $quantity ) );
+
+			// Only keep the quantity if Avarda can reproduce both line totals from the per item amounts.
+			if ( $unit_minor * $quantity === $total_minor && $unit_tax_minor * $quantity === $tax_minor ) {
+				return array(
+					'description' => substr( $description, 0, 34 ),
+					'amount'      => self::from_minor_units( $unit_minor ),
+					'taxAmount'   => self::from_minor_units( $unit_tax_minor ),
+					'quantity'    => $quantity,
+				);
+			}
+		}
+
+		// The per item amounts would lose money, so send the line as a single exact item. Keep the
+		// quantity visible in the description, since it is no longer carried by the quantity field.
+		$description = $quantity > 1 ? $quantity . ' x ' . $description : $description;
+
+		return array(
+			'description' => substr( $description, 0, 34 ),
+			'amount'      => self::from_minor_units( $total_minor ),
+			'taxAmount'   => self::from_minor_units( $tax_minor ),
+			'quantity'    => 1,
+		);
+	}
+
+	/**
+	 * Converts a price to minor units.
+	 *
+	 * @param float $amount The price in major units.
+	 * @return int
+	 */
+	private static function to_minor_units( $amount ) {
+		return intval( round( floatval( $amount ) * 100 ) );
+	}
+
+	/**
+	 * Formats a price in minor units as a two decimal string in major units.
+	 *
+	 * @param int $amount The price in minor units.
+	 * @return string
+	 */
+	private static function from_minor_units( $amount ) {
+		return number_format( $amount / 100, 2, '.', '' );
+	}
+}

--- a/classes/requests/helpers/class-aco-helper-item-amount.php
+++ b/classes/requests/helpers/class-aco-helper-item-amount.php
@@ -77,8 +77,13 @@ class ACO_Helper_Item_Amount {
 	}
 
 	/**
-	 * Truncates a description to the length Avarda accepts for the field, which their API
-	 * reference documents as 35 characters.
+	 * Truncates a description to the length the other Avarda item fields in this plugin use.
+	 *
+	 * Avarda's API reference documents the limit as 35 characters, but every call site cuts at 34.
+	 * That comes from 90da5b5 ("Change from 36 to 35 allowed characters"), which read substr()'s
+	 * third argument as an end index rather than a length - substr( $s, 0, 35 ) already returned at
+	 * most 35 characters. The unused character is left alone here so this helper stays consistent
+	 * with the call sites it does not cover, rather than being corrected in isolation.
 	 *
 	 * Counting characters rather than bytes keeps a multibyte character from being cut in half,
 	 * which would otherwise produce invalid UTF-8 in the request body.

--- a/classes/requests/helpers/class-aco-helper-item-amount.php
+++ b/classes/requests/helpers/class-aco-helper-item-amount.php
@@ -62,7 +62,9 @@ class ACO_Helper_Item_Amount {
 
 		// The per item amounts would lose money, so send the line as a single exact item. Keep the
 		// quantity visible in the description, since it is no longer carried by the quantity field.
-		if ( $raw_quantity > 1 ) {
+		// This covers fractions below one too, such as 0.5 for goods sold by weight. Quantities that
+		// are zero or negative are left out, as prefixing those would only describe the line wrongly.
+		if ( $raw_quantity > 0 && 1.0 !== $raw_quantity ) {
 			$description = (string) $raw_quantity . ' x ' . $description;
 		}
 

--- a/classes/requests/helpers/class-aco-helper-order.php
+++ b/classes/requests/helpers/class-aco-helper-order.php
@@ -217,27 +217,6 @@ class ACO_Helper_Order {
 	}
 
 	/**
-	 * Gets the item price including vat.
-	 *
-	 * @param object $order_item The order item.
-	 * @return float
-	 */
-	public static function get_item_price_incl_vat( $order_item ) {
-		$items_subtotal = ( ( $order_item->get_total() + $order_item->get_total_tax() ) / $order_item->get_quantity() );
-		return number_format( $items_subtotal, 2, '.', '' );
-	}
-
-	/**
-	 * Gets the item tax amount.
-	 *
-	 * @param object $order_item The order item.
-	 * @return float
-	 */
-	public static function get_item_tax_amount( $order_item ) {
-		return number_format( $order_item->get_total_tax() / $order_item->get_quantity(), 2, '.', '' );
-	}
-
-	/**
 	 * Get the tax rate.
 	 *
 	 * @param WC_Order                                                       $order The WooCommerce order.

--- a/classes/requests/helpers/class-aco-helper-order.php
+++ b/classes/requests/helpers/class-aco-helper-order.php
@@ -79,13 +79,20 @@ class ACO_Helper_Order {
 			$product = wc_get_product( $order_item['product_id'] );
 		}
 
+		$item = ACO_Helper_Item_Amount::get_item(
+			self::get_item_name( $order_item ),
+			$order_item->get_total() + $order_item->get_total_tax(),
+			$order_item->get_total_tax(),
+			$order_item->get_quantity()
+		);
+
 		return array(
-			'description' => substr( self::get_item_name( $order_item ), 0, 34 ), // String.
+			'description' => $item['description'], // String.
 			'notes'       => substr( self::get_reference( $order_item ), 0, 34 ), // String.
-			'amount'      => self::get_item_price_incl_vat( $order_item ), // Float.
+			'amount'      => $item['amount'], // Float.
 			'taxCode'     => self::get_product_tax_code( $order, $order_item ), // Float.
-			'taxAmount'   => self::get_item_tax_amount( $order_item ), // Float.
-			'quantity'    => $order_item->get_quantity(),
+			'taxAmount'   => $item['taxAmount'], // Float.
+			'quantity'    => $item['quantity'],
 		);
 	}
 
@@ -167,12 +174,20 @@ class ACO_Helper_Order {
 	 * @return array
 	 */
 	public function get_fee( $order, $fee ) {
+		$item = ACO_Helper_Item_Amount::get_item(
+			$fee->get_name(),
+			$fee->get_total() + $fee->get_total_tax(),
+			$fee->get_total_tax(),
+			$fee->get_quantity()
+		);
+
 		return array(
-			'description' => substr( $fee->get_name(), 0, 34 ), // String.
+			'description' => $item['description'], // String.
 			'notes'       => substr( $fee->get_id(), 0, 34 ), // String.
-			'amount'      => self::get_item_price_incl_vat( $fee ), // String.
+			'amount'      => $item['amount'], // String.
 			'taxCode'     => self::get_tax_rate( $order, $fee ), // String.
-			'taxAmount'   => self::get_item_tax_amount( $fee ), // String.
+			'taxAmount'   => $item['taxAmount'], // String.
+			'quantity'    => $item['quantity'],
 		);
 	}
 
@@ -184,12 +199,20 @@ class ACO_Helper_Order {
 	 * @return array
 	 */
 	public static function process_order_item_shipping( $order, $order_item ) {
+		$item = ACO_Helper_Item_Amount::get_item(
+			$order_item->get_name(),
+			$order_item->get_total() + $order_item->get_total_tax(),
+			$order_item->get_total_tax(),
+			$order_item->get_quantity()
+		);
+
 		return array(
-			'description' => substr( $order_item->get_name(), 0, 34 ), // String.
+			'description' => $item['description'], // String.
 			'notes'       => substr( __( 'Shipping', 'avarda-checkout-for-woocommerce' ), 0, 34 ), // String.
-			'amount'      => self::get_item_price_incl_vat( $order_item ), // String.
+			'amount'      => $item['amount'], // String.
 			'taxCode'     => self::get_tax_rate( $order, $order_item ), // Float.
-			'taxAmount'   => self::get_item_tax_amount( $order_item ),
+			'taxAmount'   => $item['taxAmount'],
+			'quantity'    => $item['quantity'],
 		);
 	}
 


### PR DESCRIPTION
https://app.clickup.com/t/2423261/869c0z37d

## The problem

Placing an order in EUR produced a total in the Avarda merchant portal that was 2 cents lower than WooCommerce's: **31.00 in Woo, 30.98 in Avarda**.

WooCommerce rounds tax at **line** level. Avarda's `Item` type is **per unit** — the order total is derived from `amount * quantity`, where `amount` is the price of a single item including tax ([API reference](https://docs.avarda.com/checkout-3/api-reference/checkout-3-api-types/)). We were dividing the line total by the quantity and rounding to two decimals, which does not survive the multiplication back:

```
5 x 4.31 excl. VAT @ 24%  ->  Woo line total incl. VAT = 26.72
26.72 / 5 = 5.344         ->  sent "5.34"
5.34 * 5  = 26.70         ->  + 4.28 shipping = 30.98, not 31.00
```

No per-unit value fixes this: `5.34 * 5 = 26.70` and `5.35 * 5 = 26.75`. Neither is 26.72.

And the per-unit value isn't even *stable* — because Woo re-rounds the line tax at every quantity, the implied per-unit price wobbles:

| qty | Woo line incl. VAT | implied per unit |
|---|---|---|
| 1 | 5.3400 | 5.3400 |
| 2 | 10.6900 | 5.3450 |
| 3 | 16.0300 | 5.3433 |
| 5 | 26.7200 | 5.3440 |

So this isn't fixable by sending more decimals either. The per-unit model simply cannot represent Woo's line totals.

This was introduced in 2d55012 (Nov 2022), which added the `quantity` field and switched `amount` from the line total to a per-unit value.

### It also blocks checkout

`ACO_Gateway::validate_totals()` tolerates a 3 minor-unit difference, which is why the reported order went through with a silent 2 cent mismatch. But the error scales with quantity, and **from quantity 8 upward it exceeds the tolerance** — the customer then gets *"The order could not be verified, please try again."* with no way to proceed:

| qty | Woo | Avarda | diff | result |
|---|---|---|---|---|
| 5 | 26.72 | 26.70 | 2c | silent mismatch (the reported case) |
| 7 | 37.41 | 37.38 | 3c | silent mismatch |
| **8** | 42.76 | 42.80 | **4c** | **checkout blocked** |
| 20 | 106.89 | 106.80 | 9c | checkout blocked |

The sign alternates too — at even quantities the per-unit value rounds up and Avarda charges *more* than Woo, at odd quantities *less* — so it couldn't have been reconciled with a fixed correction.

## The fix

New `ACO_Helper_Item_Amount::get_item()` builds `description` / `amount` / `taxAmount` / `quantity` for a line, working in integer minor units. It keeps the per-unit representation **only when Avarda can reproduce both the line total and the line tax from it**:

```php
if ( $unit_minor * $quantity === $total_minor && $unit_tax_minor * $quantity === $tax_minor ) {
    // per unit amounts + quantity - unchanged from before
}
// otherwise: a single item carrying the exact line total, quantity 1
```

When it can't, the line collapses to one item with the exact line total and `quantity: 1`, and the quantity moves into the description (`5 x Simple 25%`) so the invoice line still reads correctly.

That collapsed shape is not new to Avarda — `ACO_Helper_Create_Refund_Data` has always sent `amount` as a line total with no `quantity` at all, so we already rely on Avarda accepting it. Their docs also treat `quantity` as optional ("if quantity is used, the amount and taxAmount parameter should be defined for a single item").

Ordinary lines are untouched: a product at 10.00 excl. VAT @ 24% still goes out as `quantity: 3` at `12.40`.

Two smaller decisions in the same helper:

- **Fractional quantities always collapse.** `quantity` can't express 2.5, and flooring it to 2 would report a quantity we aren't charging for. Such lines now go out as `quantity: 1` with the exact total and `2.5 x <name>` in the description.
- **Truncation counts characters, not bytes.** `substr( $desc, 0, 34 )` could split a multibyte character, and the new `5 x ` prefix shifts where the cut lands — so a name like `Skölvägen…` could be cut mid-character and produce invalid UTF-8. `mb_substr` + `rtrim` instead. (Assumes Avarda's documented limit of "0-35 **characters**" is characters and not bytes.)

### Where it's applied

| Path | |
|---|---|
| `ACO_Helper_Cart::get_cart_item()` | checkout — **the reported bug** |
| `ACO_Helper_Order::get_order_item()` | capture / redirect / recurring — **same bug** |
| `ACO_Helper_Cart` gift cards | defensive, see below |
| `ACO_Helper_Order::get_fee()` | defensive, see below |
| `ACO_Helper_Order::process_order_item_shipping()` | defensive, see below |

Also removed three now-unreferenced public methods that still contained the divide-by-quantity logic: `ACO_Helper_Cart::get_product_price()`, `ACO_Helper_Order::get_item_price_incl_vat()` and `::get_item_tax_amount()`.

### Two of these are defensive, not fixes

Being explicit, because it would be easy to read more into the diff than is there:

- **Gift cards** looked like an overcharge — a line total sent alongside a quantity. It isn't reachable: `AbstractGiftCardCompatibility` hardcodes `set_quantity(1)` at the single place gift card lines are built. What that edit *does* change is real but minor — the description is now truncated to Avarda's limit (it wasn't before) and `amount`/`taxAmount` become two-decimal strings instead of raw floats.
- **Order fees and shipping** divided by quantity while sending no `quantity` key, which would have undercharged — but `WC_Order_Item_Fee::get_quantity()` and `WC_Order_Item_Shipping::get_quantity()` both default to `1` and WooCommerce offers no UI to change them. Routing them through the helper removes the latent divide and adds an explicit `quantity: 1`.

## Verification

**Automated — 41 checks, all passing.** Non-lossy lines keep their quantity and per-unit amount (no regression); the reported case collapses to `26.72` / `5.17`; a mixed cart is exact at every quantity 1–20; the capture path is exact; orders with product + fee + shipping are exact at qty 1/5/8; negative lines (discounts) stay exact in both paths; float traps (`0.1+0.2`, `46.20/3`, `1.005`) are exact.

**Manual, against Avarda stage** — the cart from the ticket rebuilt exactly (5 × 4.31 EUR + Flat rate 3.45, FI 24% VAT, total 31.00). Purchase, capture and refund all confirmed working, with `totalPrice: 31.00` coming back from Avarda.

## Follow-ups, deliberately not in this PR

Found while working in these files; all pre-existing:

- `ACO_Helper_Cart` sends `'note'` (singular) on gift card lines while every other line uses `'notes'`, which is what Avarda documents — gift card references are probably not reaching Avarda at all. Worth its own ticket.
- `taxCode` is formatted three different ways depending on the path: `"24"` (cart product), `"24.0000"` (order product), `"24.00"` (order fee/shipping).
- `ACO_Helper_Cart::get_fee()` computes `$fee->tax / $fee->amount * 100` with no zero guard; the sibling `get_shipping()` does guard it.
- `ACO_Helper_Cart::get_product_tax_rate()` is dead code.

No version bump or changelog entry here — those are compiled from `changelog.json` / `readme.txt` at release time.
